### PR TITLE
stricter asn parsing

### DIFF
--- a/lib/asn_grammars.ml
+++ b/lib/asn_grammars.ml
@@ -5,8 +5,15 @@ type bits = Cstruct.t
 let def  x = function None -> x | Some y -> y
 let def' x = fun y -> if y = x then None else Some y
 
+(* Error out on trailing bytes. *)
+(* XXX Is there a place where we need bytes after an ASN structure? *)
+let decode_strict codec cs =
+  match decode codec cs with
+  | Some (a, cs') when Cstruct.len cs' = 0 -> Some a
+  | _                                      -> None
+
 let projections encoding asn =
-  let c = codec encoding asn in (decode c, encode c)
+  let c = codec encoding asn in (decode_strict c, encode c)
 
 let compare_unordered_lists cmp l1 l2 =
   let rec loop = function
@@ -161,7 +168,7 @@ module General_name = struct
       | (oid, `C1 n) when oid = venezuela_1 || oid = venezuela_2 -> n
       | (oid, _    ) -> parse_error_oid "AnotherName: unrecognized oid" oid
     and g = fun _ ->
-      invalid_arg "can't encode AnotherName extentions, yet."
+      invalid_arg "can't encode AnotherName extensions, yet."
     in
     map f g @@
     sequence2

--- a/lib/certificate.ml
+++ b/lib/certificate.ml
@@ -50,8 +50,8 @@ let validate_signature trusted cert raw =
         Crypto.verifyRSA_and_unpadPKCS1 issuing_key cert.signature_val in
 
       ( match pkcs1_digest_info_of_cstruct signature with
-        | None                   -> false
-        | Some ((algo, hash), _) ->
+        | None              -> false
+        | Some (algo, hash) ->
            let compare_hashes hashfn = Utils.cs_eq hash (hashfn tbs_raw) in
            let open Algorithm in
            match (cert.signature_algo, algo) with

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -33,8 +33,8 @@ let answer_server_hello (p : security_parameters) bs sh raw =
 
 let parse_certificate c =
   match Asn_grammars.certificate_of_cstruct c with
-  | None           -> fail Packet.BAD_CERTIFICATE
-  | Some (cert, _) -> return cert
+  | None      -> fail Packet.BAD_CERTIFICATE
+  | Some cert -> return cert
 
 let answer_certificate p bs cs raw =
   (* sends nothing *)

--- a/lib/crypto_utils.ml
+++ b/lib/crypto_utils.ml
@@ -19,8 +19,8 @@ let pem_to_cstruct pem =
 let pem_to_cert pem =
   let cs = pem_to_cstruct pem in
   match Asn_grammars.certificate_of_cstruct cs with
-  | None           -> failwith "pem decode failed"
-  | Some (cert, _) -> cert
+  | None      -> failwith "pem decode failed"
+  | Some cert -> cert
 
 let cert_cstruct_of_file filename =
   let pem = read_pem_file filename in pem_to_cstruct pem
@@ -56,7 +56,7 @@ let get_key filename =
   match
     Asn_grammars.PK.rsa_private_of_cstruct (Cstruct.of_string str)
   with
-  | None         -> assert false
-  | Some (pk, _) -> pk
+  | None    -> assert false
+  | Some pk -> pk
 
 let the_key = lazy (get_key "server.key")


### PR DESCRIPTION
Check trailing bytes after ASN parse _everywhere_. It's what I wanted to do from the start.

Mitigates some [attacks](http://www.imc.org/ietf-openpgp/mail-archive/msg06063.html), too.
