### PR TITLE
Revert "use internal polymorphic compare"

### DIFF
--- a/lib/flow.ml
+++ b/lib/flow.ml
@@ -90,8 +90,13 @@ let protocol_version_cstruct =
   Cstruct.set_uint8 buf 1 minor;
   buf
 
+let protocol_version_compare (a1, a2) (b1, b2) =
+  match compare a1 b1 with
+  | 0 -> compare a2 b2
+  | c -> c
+
 let protocol_version_geq v =
-  compare v default_config.protocol_version < 1
+  protocol_version_compare v default_config.protocol_version < 1
 
 (* well-behaved pure encryptor *)
 let encrypt : crypto_state -> Packet.content_type -> Cstruct.t -> crypto_state * Cstruct.t


### PR DESCRIPTION
This reverts commit 2ddc66ef7f0967e30971a1d3b884d2f59444da9f.

Re: https://github.com/mirleft/ocaml-tls/pull/25 : although compare does work that way, I'll go with this man's opinion any day: http://stackoverflow.com/a/20348513 .

So I concur: it is underspecified.
