### PR TITLE
support for SIGNATURE_ALGORITHMS hello extension (TLS-1.2 only!):

### DIFF
--- a/lib/core.ml
+++ b/lib/core.ml
@@ -37,6 +37,7 @@ type extension =
   | ECPointFormats of ec_point_format list
   | SecureRenegotiation of Cstruct.t
   | Padding of int
+  | SignatureAlgorithms of (hash_algorithm * signature_algorithm_type) list
   | UnknownExtension of (int * Cstruct.t)
 
 type 'a hello = {

--- a/lib/flow.ml
+++ b/lib/flow.ml
@@ -4,21 +4,26 @@ open Nocrypto
 (* some config parameters *)
 type config = {
   ciphers           : Ciphersuite.ciphersuite list ;
-  protocol_versions : tls_version list
+  protocol_versions : tls_version list ;
+  hashes            : Ciphersuite.hash_algorithm list ;
+(*  signatures        : Packet.signature_algorithm_type list ; *)
 }
 
 let default_config = {
   (* ordered list (regarding preference) of supported cipher suites *)
-  ciphers           = Ciphersuite.([ TLS_RSA_WITH_AES_256_CBC_SHA ;
-                                     TLS_DHE_RSA_WITH_AES_256_CBC_SHA ;
-                                     TLS_RSA_WITH_AES_128_CBC_SHA ;
-                                     TLS_DHE_RSA_WITH_AES_128_CBC_SHA ;
-                                     TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA ;
-                                     TLS_RSA_WITH_3DES_EDE_CBC_SHA ;
-                                     TLS_RSA_WITH_RC4_128_SHA ;
-                                     TLS_RSA_WITH_RC4_128_MD5 ]) ;
+  ciphers = Ciphersuite.([ TLS_RSA_WITH_AES_256_CBC_SHA ;
+                           TLS_DHE_RSA_WITH_AES_256_CBC_SHA ;
+                           TLS_RSA_WITH_AES_128_CBC_SHA ;
+                           TLS_DHE_RSA_WITH_AES_128_CBC_SHA ;
+                           TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA ;
+                           TLS_RSA_WITH_3DES_EDE_CBC_SHA ;
+                           TLS_RSA_WITH_RC4_128_SHA ;
+                           TLS_RSA_WITH_RC4_128_MD5 ]) ;
   (* ordered list of decreasing protocol versions *)
-  protocol_versions = [ TLS_1_2 ; TLS_1_1 ; TLS_1_0 ]
+  protocol_versions = [ TLS_1_2 ; TLS_1_1 ; TLS_1_0 ] ;
+  (* orderest list (regarding preference) *)
+  hashes = Ciphersuite.([ SHA512 ; SHA384 ; SHA256 ; SHA ; MD5 ]) ;
+(*  signatures = [ Packet.RSA ] *)
 }
 
 let max_protocol_version = List.hd default_config.protocol_versions

--- a/lib/packet.ml
+++ b/lib/packet.ml
@@ -166,6 +166,18 @@ let hash_algorithm_to_int h =
   | SHA384 -> 5
   | SHA512 -> 6
 
+let hash_algorithm_to_string h =
+  let open Ciphersuite in
+  match h with
+  | NULL   -> "NULL"
+  | MD5    -> "MD5"
+  | SHA    -> "SHA1"
+  | SHA224 -> "SHA224"
+  | SHA256 -> "SHA256"
+  | SHA384 -> "SHA384"
+  | SHA512 -> "SHA512"
+
+
 (* EC RFC4492*)
 cenum ec_curve_type {
   EXPLICIT_PRIME = 1;

--- a/lib/printer.ml
+++ b/lib/printer.ml
@@ -17,6 +17,9 @@ let header_to_string (header : tls_hdr) =
 let certificate_request_to_string cr =
   "FOOO"
 
+let hash_sig_to_string (h, s) =
+  hash_algorithm_to_string h ^ " with " ^ signature_algorithm_type_to_string s
+
 let extension_to_string = function
   | Hostname host -> "Hostname: " ^ (match host with
                                      | None   -> "NONE"
@@ -27,6 +30,7 @@ let extension_to_string = function
   | ECPointFormats formats -> "Elliptic Curve formats: " ^ (String.concat ", " (List.map ec_point_format_to_string formats))
   | SecureRenegotiation _ -> "secure renegotiation"
   | Padding _ -> "padding"
+  | SignatureAlgorithms xs -> "Signature algs: " ^ (String.concat ", " (List.map hash_sig_to_string xs))
   | UnknownExtension _ -> "Unhandled extension"
 
 let client_hello_to_string c_h =


### PR DESCRIPTION
- send by the client (hash algorithm \* signature algorithm) list
- evaluated by the server to use an appropriate hash algorithm

for now, the only signature algorithm (hardcoded!) supported is RSA
