### PR TITLE
The No_validation strategy should not be used by anyone in production.

### DIFF
--- a/lwt/examples/echo_client.ml
+++ b/lwt/examples/echo_client.ml
@@ -3,7 +3,7 @@ open Ex_common
 open Lwt
 
 let echo_client host port =
-  lwt validator = X509_lwt.validator (`No_validation) in
+  lwt validator = X509_lwt.validator (`No_validation_I'M_STUPID) in
   lwt sock      = Tls_lwt.connect validator host port
   in
   let rec network () =

--- a/lwt/x509_lwt.ml
+++ b/lwt/x509_lwt.ml
@@ -76,5 +76,5 @@ let validator = function
   | `Ca_dir path ->
       certs_of_pem_dir path >|= fun cas ->
         Tls.X509.Validator.chain_of_trust ~time:0 cas
-  | `No_validation -> return Tls.X509.Validator.null
+  | `No_validation_I'M_STUPID -> return Tls.X509.Validator.null
 

--- a/lwt/x509_lwt.mli
+++ b/lwt/x509_lwt.mli
@@ -10,6 +10,6 @@ val certs_of_pem_dir : Lwt_io.file_name -> Tls.X509.Cert.t list Lwt.t
 val validator :
   [ `Ca_file of Lwt_io.file_name
   | `Ca_dir  of Lwt_io.file_name
-  | `No_validation ]
+  | `No_validation_I'M_STUPID ]
   -> validator Lwt.t
 


### PR DESCRIPTION
It is useful for testing and debugging, though. Thus, rename it to
something more obvious
