### PR TITLE
Time

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -99,7 +99,7 @@ let validate_server config =
         | None | Some ([], _) -> ()
         | Some (s::cs, ta)    ->
             match
-              Certificate.verify_chain_of_trust ~time:0 ~anchors:[ta] (s, cs)
+              Certificate.verify_chain_of_trust ~anchors:[ta] (s, cs)
             with
             | `Ok     -> ()
             | `Fail x -> invalid ("certificate chain does not validate: " ^

--- a/lwt/x509_lwt.ml
+++ b/lwt/x509_lwt.ml
@@ -68,13 +68,11 @@ let certs_of_pem_dir path =
   >>= Lwt_list.map_p (fun file -> certs_of_pem (path </> file))
   >|= List.concat
 
-
-let validator = function
-  | `Ca_file path ->
-      certs_of_pem path >|= fun cas ->
-        X509.Validator.chain_of_trust ~time:0 cas
-  | `Ca_dir path ->
-      certs_of_pem_dir path >|= fun cas ->
-        X509.Validator.chain_of_trust ~time:0 cas
+let validator param =
+  let of_cas cas =
+    let now = Unix.gettimeofday () in
+    X509.Validator.chain_of_trust ~time:now cas in
+  match param with
+  | `Ca_file path -> certs_of_pem path >|= of_cas
+  | `Ca_dir path  -> certs_of_pem_dir path >|= of_cas
   | `No_validation_I'M_STUPID -> return X509.Validator.null
-

--- a/mirage/tls_mirage.ml
+++ b/mirage/tls_mirage.ml
@@ -204,10 +204,10 @@ module X509 (KV : V1_LWT.KV_RO) = struct
   let validator kv = function
     | `Noop -> return X509.Validator.null
     | `CAs  ->
-        let time = -666 in (* get a `CLOCK` instance *)
         read_full kv ca_roots_file
         >|= X509.Cert.of_pem_cstruct
-        >|= X509.Validator.chain_of_trust ~time
+        (* Get a `CLOCK` instance! *)
+        >|= X509.Validator.chain_of_trust
 
   let certificate kv =
     let read name =


### PR DESCRIPTION
Provide it where appropriate. But not where not. Can debate whether to check the time in initial (config-creation-time) own-certificate validation to detect own expired certificate.
