### PR TITLE
Lwt reneg throttle

### DIFF
--- a/lwt/tls_lwt.ml
+++ b/lwt/tls_lwt.ml
@@ -130,6 +130,13 @@ module Unix = struct
 
   let write t cs = writev t [cs]
 
+  (*
+   * XXX bad XXX
+   * This is a point that should particularly be protected from concurrent r/w.
+   * Doing this before a `t` is returned is safe; redoing it during rekeying is
+   * not, as the API client already sees the `t` and can mistakenly interleave
+   * writes while this is in progress.
+   * *)
   let rec drain_handshake t =
     let push_linger t mcs =
       let open Tls.Utils.Cs in

--- a/mirage/tls_mirage.ml
+++ b/mirage/tls_mirage.ml
@@ -87,7 +87,13 @@ module Make (TCP: V1_LWT.TCPV4) = struct
 
   let write flow buf = writev flow [buf]
 
-
+  (*
+   * XXX bad XXX
+   * This is a point that should particularly be protected from concurrent r/w.
+   * Doing this before a `t` is returned is safe; redoing it during rekeying is
+   * not, as the API client already sees the `t` and can mistakenly interleave
+   * writes while this is in progress.
+   * *)
   let rec drain_handshake flow =
     match flow.state with
     | `Active tls when not (Tls.Engine.handshake_in_progress tls) ->


### PR DESCRIPTION
Add same logic to `lwt`. Try to document that under current setup, even forcing rekeying to complete does not really prevent unwanted interleaving; at best, it's capable of signaling when the process is over.

**TODO**: Actually _rethink_ the concurrency story.
