### PR TITLE
STARTTLS for IMAP server example

### DIFF
--- a/lwt/examples/starttls_server.ml
+++ b/lwt/examples/starttls_server.ml
@@ -1,0 +1,64 @@
+open Lwt
+
+let capability = "* OK [CAPABILITY IMAP4rev1 LITERAL+ SASL-IR LOGIN-REFERRALS ID ENABLE IDLE STARTTLS AUTH=PLAIN] server ready.\r\n"
+
+let ok_starttls = "OK STARTTLS\r\n"
+
+let cert () =
+  X509_lwt.private_of_pems
+  ~cert:"./certificates/server.pem"
+  ~priv_key:"./certificates/server.key"
+
+let init_socket addr port =
+  let sockaddr = Unix.ADDR_INET (Unix.inet_addr_of_string addr, port) in
+  let socket = Lwt_unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  Lwt_unix.setsockopt socket Unix.SO_REUSEADDR true;
+  Lwt_unix.bind socket sockaddr;
+  socket
+
+let create_srv_socket addr port =
+  let socket = init_socket addr port in
+  Lwt_unix.listen socket 10;
+  socket
+
+let accept sock =
+  Lwt_unix.accept sock >>= fun (sock_cl, addr) ->
+  let ic = Lwt_io.of_fd ~close:(fun() -> return()) ~mode:Lwt_io.input sock_cl in
+  let oc = Lwt_io.of_fd ~close:(fun() -> return()) ~mode:Lwt_io.output sock_cl in
+  return ((ic,oc), addr, sock_cl)
+
+let start_server () =
+  let sock = create_srv_socket "127.0.0.1" 143 in
+  accept sock >>= fun ((ic,oc), addr, sock_cl) ->
+  let write oc buff =
+    Lwt_io.write oc buff >> Lwt_io.flush oc
+  in
+  let read ic =
+    Lwt_io.read ic ~count:2048 >>= fun buff ->
+    Printf.printf "%s" buff;
+    return buff
+  in
+  write oc capability >>
+  read ic >>= fun buff -> 
+  let starttls = 
+    try Str.search_forward (Str.regexp "^\\([^ ]+ \\)STARTTLS") buff 0 = 0
+    with _ -> false
+  in
+  if starttls = false then
+    return ()
+  else (
+    let tag = Str.matched_group 1 buff in
+    write oc (tag ^ ok_starttls) >>
+    Lwt_io.close ic >>= fun () ->
+    Lwt_io.close oc >>= fun () ->
+    Tls_lwt.rng_init () >>= fun () ->
+    cert () >>= fun cert ->
+    Tls_lwt.Unix.server_of_fd 
+     (Tls.Config.server ~certificate:cert()) sock_cl >>= fun s ->
+    let ic,oc = Tls_lwt.of_t s in
+    read ic >>= fun _ ->
+    write oc capability
+  )
+
+let () =
+  Lwt_main.run (start_server())


### PR DESCRIPTION
code snippet for starting tis in IMAP server. works with apple email client on MAC 10.9.4.
