### PR TITLE
Tls_lwt: Do not resolve hostnames anymore, optional argument ?fd

### DIFF
--- a/lwt/tls_lwt.mli
+++ b/lwt/tls_lwt.mli
@@ -15,7 +15,7 @@ module Unix : sig
   val client_of_fd : ?trace:tracer -> Tls.Config.client -> host:string -> Lwt_unix.file_descr -> t Lwt.t
 
   val accept  : ?trace:tracer -> Tls.Config.server -> Lwt_unix.file_descr -> (t * Lwt_unix.sockaddr) Lwt.t
-  val connect : ?trace:tracer -> Tls.Config.client -> string * int -> t Lwt.t
+  val connect : ?trace:tracer -> ?fd:Lwt_unix.file_descr -> Tls.Config.client -> host:string -> Unix.sockaddr -> t Lwt.t
 
   val read   : t -> Cstruct.t      -> int  Lwt.t
   val write  : t -> Cstruct.t      -> unit Lwt.t
@@ -38,10 +38,10 @@ val accept :
   ((ic * oc) * Lwt_unix.sockaddr) Lwt.t
 
 val connect_ext :
-  ?trace:tracer -> Tls.Config.client -> string * int -> (ic * oc) Lwt.t
+  ?trace:tracer -> ?fd:Lwt_unix.file_descr -> Tls.Config.client -> host:string -> Lwt_unix.sockaddr -> (ic * oc) Lwt.t
 
 val connect :
-  ?trace:tracer -> X509_lwt.authenticator -> string * int -> (ic * oc) Lwt.t
+  ?trace:tracer -> ?fd:Lwt_unix.file_descr -> X509_lwt.authenticator -> host:string -> Lwt_unix.sockaddr -> (ic * oc) Lwt.t
 
 val of_t : Unix.t -> ic * oc
 


### PR DESCRIPTION
- The resolve function is deleted, connect functions now take an
  Lwt_unix.sockaddr instead on a host:port tuple
- There is a new ~peer argument to connect functions for TLS needs
- There is an optional ?fd argument so that the user can keep a
  reference to the fd used (and be able to do sockopts on it, for
  example).
