### PR TITLE
API for `Fingerprint authenticator added to X.509

### DIFF
--- a/lwt/x509_lwt.ml
+++ b/lwt/x509_lwt.ml
@@ -69,10 +69,14 @@ let certs_of_pem_dir path =
   >|= List.concat
 
 let authenticator param =
+  let now = Unix.gettimeofday () in
   let of_cas cas =
-    let now = Unix.gettimeofday () in
     X509.Authenticator.chain_of_trust ~time:now cas in
   match param with
   | `Ca_file path -> certs_of_pem path >|= of_cas
   | `Ca_dir path  -> certs_of_pem_dir path >|= of_cas
+  | `Fingerprint fp ->
+    let fp = String.map (function | ':' -> ' ' | x -> x) fp in
+    let server_fingerprint = Nocrypto.Uncommon.Cs.of_hex fp in
+    return (X509.Authenticator.server_fingerprint ~time:now ~server_fingerprint)
   | `No_authentication_I'M_STUPID -> return X509.Authenticator.null

--- a/lwt/x509_lwt.mli
+++ b/lwt/x509_lwt.mli
@@ -10,6 +10,7 @@ val certs_of_pem_dir : Lwt_io.file_name -> X509.Cert.t list Lwt.t
 val authenticator :
   [ `Ca_file of Lwt_io.file_name
   | `Ca_dir  of Lwt_io.file_name
+  | `Fingerprint of string
   | `No_authentication_I'M_STUPID ]
   -> authenticator Lwt.t
 


### PR DESCRIPTION
requires a SHA-256 fingerprint (as hex, ':' allowed) of the server certificate
