### PR TITLE
fully marshal dh groups

### DIFF
--- a/lib/crypto.ml
+++ b/lib/crypto.ml
@@ -10,12 +10,13 @@ let (<+>) = Utils.Cs.(<+>)
 
 
 (* on-the-wire dh_params <-> (group, pub_message) *)
-let dh_params_pack group message =
-  let (p, g) = Dh.to_cstruct group in
-  { Core.dh_p = p ; dh_g = g ; dh_Ys = message }
+let dh_params_pack { Dh.p; gg } message =
+  let cs_of_z = Numeric.Z.to_cstruct_be ?size:None in
+  { Core.dh_p = cs_of_z p ; dh_g = cs_of_z gg ; dh_Ys = message }
 
 and dh_params_unpack { Core.dh_p ; dh_g ; dh_Ys } =
-  ( Dh.group ~p:dh_p ~gg:dh_g (), dh_Ys )
+  let z_of_cs = Numeric.Z.of_cstruct_be ?bits:None in
+  ({ Dh.p = z_of_cs dh_p ; gg = z_of_cs dh_g ; q = None }, dh_Ys)
 
 let dh_shared group secret public =
   try Some (Dh.shared group secret public)


### PR DESCRIPTION
Avoid reliance on ad-hoc key marshalling from `nocrypto`.

Harmonizes with https://github.com/mirleft/ocaml-nocrypto/commit/3cea42f7f3f254865ffa4c1d51dfd3b4d10aff27, which removes it.
