### PR TITLE
Fix for moved module types

### DIFF
--- a/lib/crypto.ml
+++ b/lib/crypto.ml
@@ -24,7 +24,7 @@ let dh_shared group secret public =
 
 
 type 'k stream_cipher = (module Cipher_stream.T    with type key = 'k)
-type 'k cbc_cipher    = (module Cipher_block.T_CBC with type key = 'k)
+type 'k cbc_cipher    = (module Cipher_block.T.CBC with type key = 'k)
 
 module Ciphers = struct
 
@@ -42,17 +42,17 @@ module Ciphers = struct
 
     | TRIPLE_DES_EDE_CBC ->
         let open Cipher_block.DES in
-        K_CBC ( (module CBC : Cipher_block.T_CBC with type key = CBC.key),
+        K_CBC ( (module CBC : Cipher_block.T.CBC with type key = CBC.key),
                 CBC.of_secret secret )
 
     | AES_128_CBC ->
         let open Cipher_block.AES in
-        K_CBC ( (module CBC : Cipher_block.T_CBC with type key = CBC.key),
+        K_CBC ( (module CBC : Cipher_block.T.CBC with type key = CBC.key),
                 CBC.of_secret secret )
 
     | AES_256_CBC ->
         let open Cipher_block.AES in
-        K_CBC ( (module CBC : Cipher_block.T_CBC with type key = CBC.key),
+        K_CBC ( (module CBC : Cipher_block.T.CBC with type key = CBC.key),
                 CBC.of_secret secret )
 end
 
@@ -75,7 +75,7 @@ let mac (hash, key) seq ty (v_major, v_minor) data =
   Hash.mac hash ~key (prefix <+> data)
 
 let cbc_block (type a) cipher =
-  let module C = (val cipher : Cipher_block.T_CBC with type key = a) in C.block_size
+  let module C = (val cipher : Cipher_block.T.CBC with type key = a) in C.block_size
 
 let encrypt_stream (type a) ~cipher ~key data =
   let module C = (val cipher : Cipher_stream.T with type key = a) in
@@ -121,13 +121,13 @@ let cbc_unpad ~block data =
 
 
 let encrypt_cbc (type a) ~cipher ~key ~iv data =
-  let module C = (val cipher : Cipher_block.T_CBC with type key = a) in
+  let module C = (val cipher : Cipher_block.T.CBC with type key = a) in
   let { C.message ; iv } =
     C.encrypt ~key ~iv (data <+> cbc_pad C.block_size data) in
   (message, iv)
 
 let decrypt_cbc (type a) ~cipher ~key ~iv data =
-  let module C = (val cipher : Cipher_block.T_CBC with type key = a) in
+  let module C = (val cipher : Cipher_block.T.CBC with type key = a) in
   try
     let { C.message ; iv } = C.decrypt ~key ~iv data in
     match cbc_unpad C.block_size message with


### PR DESCRIPTION
In the course of preparing `nocrypto` for a release, I had to break the api ever so slightly...

:unamused: 
