### PR TITLE
Last second fixes

### DIFF
--- a/mirage/tls_mirage.ml
+++ b/mirage/tls_mirage.ml
@@ -59,8 +59,9 @@ module Make (F : V1_LWT.FLOW) (E : V1_LWT.ENTROPY) = struct
     let open Cstruct in
     let blen = len buf in
     let io = Io_page.get (Uncommon.cdiv blen 4096) in
-    Io_page.string_blit (to_string buf) 0 io 0 blen ;
-    sub (Io_page.to_cstruct io) 0 blen
+    let cs = Cstruct.(of_bigarray ~len:blen io) in
+    Cstruct.blit buf 0 cs 0 blen ;
+    cs
 
   let read_react flow =
 


### PR DESCRIPTION
Just a touch-up for the `io-page` case:

Allocator improvements can definitely wait for a future release, but I thought why not just do a cons followed by a [memmove](https://github.com/mirage/ocaml-cstruct/blob/master/lib/cstruct_stubs.c#L47), instead of a [memcpy](https://github.com/mirage/ocaml-cstruct/blob/master/lib/cstruct_stubs.c#L29), a [spin](https://github.com/mirage/io-page/blob/master/lib/io_page.ml#L74), and two conses -- right away?

Should be plenty fast. :metal:

Release away!
