### PR TITLE
Use the now-manifest x509.authenticator type

### DIFF
--- a/lib/handshake_common.ml
+++ b/lib/handshake_common.ml
@@ -210,10 +210,8 @@ let verify_digitally_signed version data signature_data certificates =
 let validate_chain authenticator certificates hostname =
   let open Certificate in
 
-  let authenticate authenticator server_name certificates =
-    match
-      X509.Authenticator.authenticate ?host:server_name authenticator certificates
-    with
+  let authenticate authenticator host certificates =
+    match authenticator ?host certificates with
     | `Fail (SelfSigned _)         -> fail Packet.UNKNOWN_CA
     | `Fail NoTrustAnchor          -> fail Packet.UNKNOWN_CA
     | `Fail (CertificateExpired _) -> fail Packet.CERTIFICATE_EXPIRED


### PR DESCRIPTION
The other part of https://github.com/mirleft/ocaml-x509/pull/39.