### PR TITLE
Remove manual Io_page juggling

### DIFF
--- a/mirage/tls_mirage.ml
+++ b/mirage/tls_mirage.ml
@@ -55,14 +55,6 @@ module Make (F : V1_LWT.FLOW) (E : V1_LWT.ENTROPY) = struct
     | None      -> f ()
     | Some hook -> Tls.Tracing.active ~hook f
 
-  let conv_io buf =
-    let open Cstruct in
-    let blen = len buf in
-    let io = Io_page.get (Uncommon.cdiv blen 4096) in
-    let cs = Cstruct.(of_bigarray ~len:blen io) in
-    Cstruct.blit buf 0 cs 0 blen ;
-    cs
-
   let read_react flow =
 
     let handle tls buf =
@@ -76,7 +68,7 @@ module Make (F : V1_LWT.FLOW) (E : V1_LWT.ENTROPY) = struct
             | `Alert alert -> tls_alert alert );
           ( match resp with
             | None     -> return_ok
-            | Some buf -> FLOW.write flow.flow (conv_io buf) >>= check_write flow ) >>
+            | Some buf -> FLOW.write flow.flow buf >>= check_write flow ) >>
           ( match res with
             | `Ok _ -> return_unit
             | _     -> FLOW.close flow.flow ) >>
@@ -84,7 +76,7 @@ module Make (F : V1_LWT.FLOW) (E : V1_LWT.ENTROPY) = struct
       | `Fail (alert, `Response resp) ->
           let reason = tls_alert alert in
           flow.state <- reason ;
-          FLOW.(write flow.flow (conv_io resp) >> close flow.flow) >> return reason
+          FLOW.(write flow.flow resp >> close flow.flow) >> return reason
     in
     match flow.state with
     | `Eof | `Error _ as e -> return e
@@ -113,7 +105,7 @@ module Make (F : V1_LWT.FLOW) (E : V1_LWT.ENTROPY) = struct
         with
         | Some (tls, answer) ->
             flow.state <- `Active tls ;
-            FLOW.write flow.flow (conv_io answer) >>= check_write flow
+            FLOW.write flow.flow answer >>= check_write flow
         | None ->
             (* "Impossible" due to handhake draining. *)
             return_tls_error "write: flow not ready to send"
@@ -148,7 +140,7 @@ module Make (F : V1_LWT.FLOW) (E : V1_LWT.ENTROPY) = struct
         | None             -> return_tls_error "renegotiation in progress"
         | Some (tls', buf) ->
             flow.state <- `Active tls' ;
-            FLOW.write flow.flow (conv_io buf) >|= lift_result
+            FLOW.write flow.flow buf >|= lift_result
 
   let close flow =
     match flow.state with
@@ -156,7 +148,7 @@ module Make (F : V1_LWT.FLOW) (E : V1_LWT.ENTROPY) = struct
       flow.state <- `Eof ;
       let (_, buf) = tracing flow @@ fun () ->
         Tls.Engine.send_close_notify tls in
-      FLOW.(write flow.flow (conv_io buf) >> close flow.flow)
+      FLOW.(write flow.flow buf >> close flow.flow)
     | _           -> return_unit
 
   let client_of_flow ?trace conf host flow =
@@ -168,7 +160,7 @@ module Make (F : V1_LWT.FLOW) (E : V1_LWT.ENTROPY) = struct
       linger = [] ;
       tracer = trace ;
     } in
-    FLOW.write flow (conv_io init) >> drain_handshake tls_flow
+    FLOW.write flow init >> drain_handshake tls_flow
 
   let server_of_flow ?trace conf flow =
     let tls_flow = {


### PR DESCRIPTION
Don't touch `Io_page` directly, assume any `Cstruct.t` can be sent over TCP.

Adds compatibility with recent `io-page` too; breaks compatibility with `mirage-net-xen` < 1.3.0 (before https://github.com/mirage/mirage-net-xen/commit/7d2777d789530e2104b6d9252cdca0d6f8078acb).