### PR TITLE
Mirage: expose Epoch

### DIFF
--- a/mirage/tls_mirage.ml
+++ b/mirage/tls_mirage.ml
@@ -180,6 +180,14 @@ module Make (F : V1_LWT.FLOW) (E : V1_LWT.ENTROPY) = struct
     } in
     drain_handshake tls_flow
 
+  let epoch flow =
+    match flow.state with
+    | `Eof | `Error _ -> `Error
+    | `Active tls     ->
+        match Tls.Engine.epoch tls with
+        | `InitialEpoch -> assert false (* `drain_handshake` invariant. *)
+        | `Epoch e      -> `Ok e
+
 (*   let create_connection t tls_params host (addr, port) =
     |+ XXX addr -> (host : string) +|
     TCP.create_connection t (addr, port) >>= function

--- a/mirage/tls_mirage.mli
+++ b/mirage/tls_mirage.mli
@@ -27,6 +27,8 @@ module Make (F : V1_LWT.FLOW) (E : V1_LWT.ENTROPY) : sig
     ?trace:tracer -> Tls.Config.server -> FLOW.flow ->
     [> `Ok of flow | `Error of error ] Lwt.t
 
+  val epoch : flow -> [ `Ok of Tls.Engine.epoch_data | `Error ]
+
 end
   with module FLOW    = F
    and module ENTROPY = E


### PR DESCRIPTION
Add `epoch` projection to `tls.mirage` interface; mirrors the one in `tls.lwt`.