### PR TITLE
always require secure renegotiation

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -21,7 +21,6 @@ type config = {
   hashes            : Hash.hash list ;
   (* signatures        : Packet.signature_algorithm_type list ; *)
   use_reneg         : bool ;
-  secure_reneg      : bool ;
   authenticator     : X509.Authenticator.t option ;
   peer_name         : string option ;
   own_certificates  : own_cert ;
@@ -77,7 +76,6 @@ let default_config = {
   protocol_versions = (TLS_1_0, TLS_1_2) ;
   hashes            = default_hashes ;
   use_reneg         = true ;
-  secure_reneg      = true ;
   authenticator     = None ;
   peer_name         = None ;
   own_certificates  = `None ;
@@ -207,7 +205,7 @@ let peer conf name = { conf with peer_name = Some name }
 let (<?>) ma b = match ma with None -> b | Some a -> a
 
 let client
-  ~authenticator ?ciphers ?version ?hashes ?reneg ?certificates ?secure_reneg () =
+  ~authenticator ?ciphers ?version ?hashes ?reneg ?certificates () =
   let config =
     { default_config with
         authenticator     = Some authenticator ;
@@ -216,12 +214,11 @@ let client
         hashes            = hashes       <?> default_config.hashes ;
         use_reneg         = reneg        <?> default_config.use_reneg ;
         own_certificates  = certificates <?> default_config.own_certificates ;
-        secure_reneg      = secure_reneg <?> default_config.secure_reneg ;
     } in
   ( validate_common config ; validate_client config ; config )
 
 let server
-  ?ciphers ?version ?hashes ?reneg ?certificates ?authenticator ?secure_reneg () =
+  ?ciphers ?version ?hashes ?reneg ?certificates ?authenticator () =
   let config =
     { default_config with
         ciphers           = ciphers      <?> default_config.ciphers ;
@@ -230,7 +227,6 @@ let server
         use_reneg         = reneg        <?> default_config.use_reneg ;
         own_certificates  = certificates <?> default_config.own_certificates ;
         authenticator     = authenticator ;
-        secure_reneg      = secure_reneg <?> default_config.secure_reneg ;
     } in
   ( validate_common config ; validate_server config ; config )
 

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -20,7 +20,6 @@ type config = private {
   protocol_versions : tls_version * tls_version ; (** supported protocol versions (min, max) *)
   hashes            : Hash.hash list ; (** ordered list of supported hash algorithms (regarding preference) *)
   use_reneg         : bool ; (** endpoint should accept renegotiation requests *)
-  secure_reneg      : bool ; (** other end must use secure renegotiation (RFC 5746) *)
   authenticator     : X509.Authenticator.t option ; (** optional X509 authenticator *)
   peer_name         : string option ; (** optional name of other endpoint (used for SNI RFC4366) *)
   own_certificates  : own_cert ; (** optional default certificate chain and other certificate chains *)
@@ -72,7 +71,7 @@ val of_client : client -> config
 (** [of_server server] is a server configuration for [server] *)
 val of_server : server -> config
 
-(** [client ?ciphers ?version ?hashes ?reneg ?certificates ?secure_reneg] is [client] configuration with the given parameters *)
+(** [client authenticator ?ciphers ?version ?hashes ?reneg ?certificates] is [client] configuration with the given parameters *)
 (** @raise Invalid_argument if the configuration is invalid *)
 val client :
   authenticator  : X509.Authenticator.t ->
@@ -81,10 +80,9 @@ val client :
   ?hashes        : Hash.hash list ->
   ?reneg         : bool ->
   ?certificates  : own_cert ->
-  ?secure_reneg  : bool ->
   unit -> client
 
-(** [server ?ciphers ?version ?hashes ?reneg ?certificates ?authenticator ?secure_reneg] is [server] configuration with the given parameters *)
+(** [server ?ciphers ?version ?hashes ?reneg ?certificates ?authenticator] is [server] configuration with the given parameters *)
 (** @raise Invalid_argument if the configuration is invalid *)
 val server :
   ?ciphers       : Ciphersuite.ciphersuite list ->
@@ -93,5 +91,4 @@ val server :
   ?reneg         : bool ->
   ?certificates  : own_cert ->
   ?authenticator : X509.Authenticator.t ->
-  ?secure_reneg  : bool ->
   unit -> server

--- a/lwt/examples/http_client.ml
+++ b/lwt/examples/http_client.ml
@@ -15,7 +15,7 @@ let http_client ?ca ?fp host port =
   lwt (ic, oc) =
     Tls_lwt.connect_ext
       ~trace:eprint_sexp
-      (Tls.Config.client ~authenticator ~secure_reneg:false ())
+      (Tls.Config.client ~authenticator ())
       (host, port) in
   let req = String.concat "\r\n" [
     "GET / HTTP/1.1" ; "Host: " ^ host ; "Connection: close" ; "" ; ""


### PR DESCRIPTION
not requiring this leaves us otherwise open to MITM prefix
attacks.  RFC5746 is out since > 5 years.  no reason to allow
the insecure option.