### PR TITLE
rename pfs to fs -- there's nothing perfect in forward secrecy

### DIFF
--- a/lib/ciphersuite.ml
+++ b/lib/ciphersuite.ml
@@ -141,7 +141,7 @@ let ciphersuite_kex c = fst (get_kex_privprot c)
 (** [ciphersuite_privprot ciphersuite] is [privprot], second projection of [get_kex_privprot] *)
 let ciphersuite_privprot c = snd (get_kex_privprot c)
 
-let ciphersuite_pfs cs =
+let ciphersuite_fs cs =
   match ciphersuite_kex cs with
   | DHE_RSA -> true
   | RSA     -> false

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -55,9 +55,9 @@ module Ciphers = struct
     `TLS_RSA_WITH_RC4_128_MD5
     ]
 
-  let pfs_of = List.filter Ciphersuite.ciphersuite_pfs
+  let fs_of = List.filter Ciphersuite.ciphersuite_pfs
 
-  let pfs = pfs_of default
+  let fs = fs_of default
 
 end
 

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -55,7 +55,7 @@ module Ciphers = struct
     `TLS_RSA_WITH_RC4_128_MD5
     ]
 
-  let fs_of = List.filter Ciphersuite.ciphersuite_pfs
+  let fs_of = List.filter Ciphersuite.ciphersuite_fs
 
   let fs = fs_of default
 

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -93,16 +93,18 @@ module Ciphers : sig
   (** {1 Cipher selection} *)
 
   val default : ciphersuite list
-  (** All ciphersuites this library uses by default. *)
+  (** [default] is a list of ciphersuites this library uses by default. *)
 
   val supported : ciphersuite list
-  (** All ciphersuites this library implements. *)
+  (** [supported] is a list of ciphersuites this library supports
+      (larger than [default]). *)
 
   val fs : ciphersuite list
-  (** All forward secrecy ciphersuites this library supports. *)
+  (** [fs] is a list of ciphersuites which are forward secure (sublist
+      of [default]). *)
 
   val fs_of : ciphersuite list -> ciphersuite list
-  (** [pfs_of ciphers] selects all forward secrecy ciphersuites from default. *)
+  (** [fs_of ciphers] selects all forward secrecy ciphersuites from ciphers. *)
 end
 
 (** {1 Internal use only} *)

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -98,11 +98,11 @@ module Ciphers : sig
   val supported : ciphersuite list
   (** All ciphersuites this library implements. *)
 
-  val pfs : ciphersuite list
-  (** All perfect forward secrecy ciphersuites this library supports. *)
+  val fs : ciphersuite list
+  (** All forward secrecy ciphersuites this library supports. *)
 
-  val pfs_of : ciphersuite list -> ciphersuite list
-  (** [pfs_of ciphers] selects all perfect forward secrecy ciphersuites from default. *)
+  val fs_of : ciphersuite list -> ciphersuite list
+  (** [pfs_of ciphers] selects all forward secrecy ciphersuites from default. *)
 end
 
 (** {1 Internal use only} *)


### PR DESCRIPTION
(actually, a better name is `key erasure` (djb))