### PR TITLE
Session resumption

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -15,7 +15,7 @@ type own_cert = [
   | `Multiple_default of certchain * certchain list
 ] with sexp
 
-type session_cache = Cstruct.t -> epoch_data option
+type session_cache = SessionID.t -> epoch_data option
 let session_cache_of_sexp _ = fun _ -> None
 let sexp_of_session_cache _ = Sexplib.Sexp.Atom "SESSION_CACHE"
 

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -15,6 +15,10 @@ type own_cert = [
   | `Multiple_default of certchain * certchain list
 ] with sexp
 
+type session_cache = Cstruct.t option -> epoch_data option
+let session_cache_of_sexp _ = fun _ -> None
+let sexp_of_session_cache _ = Sexplib.Sexp.Atom "SESSION_CACHE"
+
 type config = {
   ciphers           : Ciphersuite.ciphersuite list ;
   protocol_versions : tls_version * tls_version ;
@@ -24,6 +28,7 @@ type config = {
   authenticator     : X509.Authenticator.a option ;
   peer_name         : string option ;
   own_certificates  : own_cert ;
+  session_cache     : session_cache ;
 } with sexp
 
 module Ciphers = struct
@@ -81,6 +86,7 @@ let default_config = {
   authenticator     = None ;
   peer_name         = None ;
   own_certificates  = `None ;
+  session_cache     = fun _ -> None ;
 }
 
 let invalid msg = invalid_arg ("Tls.Config: invalid configuration: " ^ msg)
@@ -205,28 +211,30 @@ let peer conf name = { conf with peer_name = Some name }
 let (<?>) ma b = match ma with None -> b | Some a -> a
 
 let client
-  ~authenticator ?ciphers ?version ?hashes ?reneg ?certificates () =
+  ~authenticator ?ciphers ?version ?hashes ?reneg ?certificates ?session_cache () =
   let config =
     { default_config with
         authenticator     = Some authenticator ;
-        ciphers           = ciphers      <?> default_config.ciphers ;
-        protocol_versions = version      <?> default_config.protocol_versions ;
-        hashes            = hashes       <?> default_config.hashes ;
-        use_reneg         = reneg        <?> default_config.use_reneg ;
-        own_certificates  = certificates <?> default_config.own_certificates ;
+        ciphers           = ciphers       <?> default_config.ciphers ;
+        protocol_versions = version       <?> default_config.protocol_versions ;
+        hashes            = hashes        <?> default_config.hashes ;
+        use_reneg         = reneg         <?> default_config.use_reneg ;
+        own_certificates  = certificates  <?> default_config.own_certificates ;
+        session_cache     = session_cache <?> default_config.session_cache ;
     } in
   ( validate_common config ; validate_client config ; config )
 
 let server
-  ?ciphers ?version ?hashes ?reneg ?certificates ?authenticator () =
+  ?ciphers ?version ?hashes ?reneg ?certificates ?authenticator ?session_cache () =
   let config =
     { default_config with
-        ciphers           = ciphers      <?> default_config.ciphers ;
-        protocol_versions = version      <?> default_config.protocol_versions ;
-        hashes            = hashes       <?> default_config.hashes ;
-        use_reneg         = reneg        <?> default_config.use_reneg ;
-        own_certificates  = certificates <?> default_config.own_certificates ;
+        ciphers           = ciphers       <?> default_config.ciphers ;
+        protocol_versions = version       <?> default_config.protocol_versions ;
+        hashes            = hashes        <?> default_config.hashes ;
+        use_reneg         = reneg         <?> default_config.use_reneg ;
+        own_certificates  = certificates  <?> default_config.own_certificates ;
         authenticator     = authenticator ;
+        session_cache     = session_cache <?> default_config.session_cache ;
     } in
   ( validate_common config ; validate_server config ; config )
 

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -16,6 +16,8 @@ type own_cert = [
   | `Multiple_default of certchain * certchain list
 ]
 
+type session_cache = Cstruct.t option -> epoch_data option
+
 (** configuration parameters *)
 type config = private {
   ciphers           : Ciphersuite.ciphersuite list ; (** ordered list (regarding preference) of supported cipher suites *)
@@ -25,6 +27,7 @@ type config = private {
   authenticator     : X509.Authenticator.a option ; (** optional X509 authenticator *)
   peer_name         : string option ; (** optional name of other endpoint (used for SNI RFC4366) *)
   own_certificates  : own_cert ; (** optional default certificate chain and other certificate chains *)
+  session_cache     : session_cache ;
 }
 
 val config_of_sexp : Sexplib.Sexp.t -> config
@@ -53,6 +56,7 @@ val client :
   ?hashes        : Hash.hash list ->
   ?reneg         : bool ->
   ?certificates  : own_cert ->
+  ?session_cache : session_cache ->
   unit -> client
 
 (** [server ?ciphers ?version ?hashes ?reneg ?certificates ?authenticator] is [server] configuration with the given parameters *)
@@ -64,6 +68,7 @@ val server :
   ?reneg         : bool ->
   ?certificates  : own_cert ->
   ?authenticator : X509.Authenticator.a ->
+  ?session_cache : session_cache ->
   unit -> server
 
 (** [peer client name] is [client] with [name] as [peer_name] *)

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -16,7 +16,7 @@ type own_cert = [
   | `Multiple_default of certchain * certchain list
 ]
 
-type session_cache = Cstruct.t option -> epoch_data option
+type session_cache = Cstruct.t -> epoch_data option
 
 (** configuration parameters *)
 type config = private {
@@ -28,6 +28,7 @@ type config = private {
   peer_name         : string option ; (** optional name of other endpoint (used for SNI RFC4366) *)
   own_certificates  : own_cert ; (** optional default certificate chain and other certificate chains *)
   session_cache     : session_cache ;
+  cached_session    : epoch_data option ;
 }
 
 val config_of_sexp : Sexplib.Sexp.t -> config
@@ -50,13 +51,13 @@ val sexp_of_server : server -> Sexplib.Sexp.t
 (** [client authenticator ?ciphers ?version ?hashes ?reneg ?certificates] is [client] configuration with the given parameters *)
 (** @raise Invalid_argument if the configuration is invalid *)
 val client :
-  authenticator  : X509.Authenticator.a ->
-  ?ciphers       : Ciphersuite.ciphersuite list ->
-  ?version       : tls_version * tls_version ->
-  ?hashes        : Hash.hash list ->
-  ?reneg         : bool ->
-  ?certificates  : own_cert ->
-  ?session_cache : session_cache ->
+  authenticator   : X509.Authenticator.a ->
+  ?ciphers        : Ciphersuite.ciphersuite list ->
+  ?version        : tls_version * tls_version ->
+  ?hashes         : Hash.hash list ->
+  ?reneg          : bool ->
+  ?certificates   : own_cert ->
+  ?cached_session : epoch_data ->
   unit -> client
 
 (** [server ?ciphers ?version ?hashes ?reneg ?certificates ?authenticator] is [server] configuration with the given parameters *)

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -16,7 +16,7 @@ type own_cert = [
   | `Multiple_default of certchain * certchain list
 ]
 
-type session_cache = Cstruct.t -> epoch_data option
+type session_cache = SessionID.t -> epoch_data option
 
 (** configuration parameters *)
 type config = private {

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -170,4 +170,5 @@ type epoch_data = {
   own_private_key  : Nocrypto.Rsa.priv option ;
   own_name         : string option ;
   master_secret    : master_secret ;
+  session_id       : Cstruct.t ;
 } with sexp

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -66,6 +66,13 @@ type tls_hdr = {
   version      : tls_any_version;
 } with sexp
 
+module SessionID = struct
+  type t = Cstruct.t with sexp
+  let compare = Cstruct.compare
+  let hash = Hashtbl.hash
+  let equal = Cstruct.equal
+end
+
 type extension =
   | Hostname of string option
   | MaxFragmentLength of max_fragment_length
@@ -80,7 +87,7 @@ type extension =
 type ('a, 'b) hello = {
   version      : 'b;
   random       : Cstruct.t;
-  sessionid    : Cstruct.t option;
+  sessionid    : SessionID.t option;
   ciphersuites : 'a;
   extensions   : extension list
 } with sexp
@@ -170,5 +177,5 @@ type epoch_data = {
   own_private_key  : Nocrypto.Rsa.priv option ;
   own_name         : string option ;
   master_secret    : master_secret ;
-  session_id       : Cstruct.t ;
+  session_id       : SessionID.t ;
 } with sexp

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -69,7 +69,7 @@ type tls_hdr = {
 module SessionID = struct
   type t = Cstruct.t with sexp
   let compare = Cstruct.compare
-  let hash = Hashtbl.hash
+  let hash t = Hashtbl.hash (Cstruct.to_bigarray t)
   let equal = Cstruct.equal
 end
 

--- a/lib/engine.ml
+++ b/lib/engine.ml
@@ -303,7 +303,9 @@ let hs_can_handle_appdata s =
        new crypto context, not authenticated by Finished, is in use *)
     match s.machina with
     | Server (AwaitClientFinished _)
-    | Client (AwaitServerFinished _) -> false
+    | Server (AwaitClientFinishedResume _)
+    | Client (AwaitServerFinished _)
+    | Client (AwaitServerFinishedResume _) -> false
     | _ -> true
 
 let rec separate_handshakes buf =

--- a/lib/engine.ml
+++ b/lib/engine.ml
@@ -578,4 +578,5 @@ let epoch state =
         own_private_key  = session.own_private_key ;
         own_name         = session.own_name ;
         master_secret    = session.master_secret ;
+        session_id       = session.session_id ;
       }

--- a/lib/handshake_client.ml
+++ b/lib/handshake_client.ml
@@ -218,8 +218,13 @@ let answer_certificate_request state session cr kex pms raw log =
 let answer_server_hello_done state session sigalgs kex premaster raw log =
   let kex = ClientKeyExchange kex in
   let ckex = Writer.assemble_handshake kex in
-  let client_ctx, server_ctx, master_secret =
-    Handshake_crypto.initialise_crypto_ctx state.protocol_version session premaster in
+  let master_secret =
+    Handshake_crypto.derive_master_secret state.protocol_version session premaster
+  in
+  let session = { session with master_secret } in
+  let client_ctx, server_ctx =
+    Handshake_crypto.initialise_crypto_ctx state.protocol_version session
+  in
 
   ( match session.client_auth, session.own_private_key with
     | true, Some p ->

--- a/lib/handshake_common.ml
+++ b/lib/handshake_common.ml
@@ -37,6 +37,7 @@ let empty_session = {
   master_secret    = Cstruct.create 0 ;
   renegotiation    = Cstruct.(create 0, create 0) ;
   client_auth      = false ;
+  session_id       = Cstruct.create 0 ;
 }
 
 let supported_protocol_version (min, max) v =

--- a/lib/handshake_common.ml
+++ b/lib/handshake_common.ml
@@ -40,6 +40,18 @@ let empty_session = {
   session_id       = Cstruct.create 0 ;
 }
 
+let session_of_epoch (epoch : epoch_data) : session_data = {
+  empty_session with
+  ciphersuite = epoch.ciphersuite ;
+  peer_certificate = epoch.peer_certificate ;
+  trust_anchor = epoch.trust_anchor ;
+  own_certificate = epoch.own_certificate ;
+  own_private_key = epoch.own_private_key ;
+  master_secret = epoch.master_secret ;
+  own_name = epoch.own_name ;
+  session_id = epoch.session_id
+}
+
 let supported_protocol_version (min, max) v =
   match version_ge v min, version_ge v max with
     | _   , true -> Some max

--- a/lib/handshake_crypto.ml
+++ b/lib/handshake_crypto.ml
@@ -58,16 +58,19 @@ let divide_keyblock key mac iv buf =
   in
   (c_mac, s_mac, c_key, s_key, c_iv, s_iv)
 
+let derive_master_secret version session premaster =
+  let client_random = session.client_random
+  and server_random = session.server_random
+  in
+  generate_master_secret version premaster (client_random <+> server_random)
 
-let initialise_crypto_ctx version session premaster =
+let initialise_crypto_ctx version session =
   let open Ciphersuite in
   let client_random = session.client_random
   and server_random = session.server_random
+  and master = session.master_secret
   and cipher = session.ciphersuite
   in
-
-  let master = generate_master_secret version premaster
-                (client_random <+> server_random) in
 
   let pp = ciphersuite_privprot cipher in
 
@@ -99,4 +102,4 @@ let initialise_crypto_ctx version session premaster =
   let c_context = context c_key c_iv c_mac
   and s_context = context s_key s_iv s_mac in
 
-  (c_context, s_context, master)
+  (c_context, s_context)

--- a/lib/handshake_crypto.mli
+++ b/lib/handshake_crypto.mli
@@ -1,4 +1,5 @@
 open State
 
-val initialise_crypto_ctx : Core.tls_version -> session_data -> Cstruct.t -> (crypto_context * crypto_context * Cstruct.t)
+val derive_master_secret : Core.tls_version -> session_data -> Cstruct.t -> Core.master_secret
+val initialise_crypto_ctx : Core.tls_version -> session_data -> (crypto_context * crypto_context)
 val finished : Core.tls_version -> Cstruct.t -> string -> Cstruct.t list -> Cstruct.t

--- a/lib/handshake_server.ml
+++ b/lib/handshake_server.ml
@@ -37,10 +37,13 @@ let answer_client_finished state session client_fin raw log =
    [`Record (Packet.HANDSHAKE, fin_raw)])
 
 let establish_master_secret state session premastersecret raw log =
-  let client_ctx, server_ctx, master_secret =
-    Handshake_crypto.initialise_crypto_ctx state.protocol_version session premastersecret
+  let master_secret = Handshake_crypto.derive_master_secret
+      state.protocol_version session premastersecret
   in
   let session = { session with master_secret = master_secret } in
+  let client_ctx, server_ctx =
+    Handshake_crypto.initialise_crypto_ctx state.protocol_version session
+  in
   let machina =
     match session.peer_certificate with
     | [] -> AwaitClientChangeCipherSpec (session, server_ctx, client_ctx, log @ [raw])

--- a/lib/handshake_server.ml
+++ b/lib/handshake_server.ml
@@ -319,7 +319,7 @@ let answer_client_hello state (ch : client_hello) raw =
       version = epoch.protocol_version
     in
 
-    match state.config.session_cache ch.sessionid with
+    match option None state.config.session_cache ch.sessionid with
     | Some epoch when epoch_matches epoch state.protocol_version ch.ciphersuites ->
       Some { session_of_epoch epoch with
              client_random = ch.random ;

--- a/lib/state.ml
+++ b/lib/state.ml
@@ -81,6 +81,7 @@ type session_data = {
   renegotiation    : reneg_params ; (* renegotiation data *)
   own_name         : string option ;
   client_auth      : bool ;
+  session_id       : Cstruct.t ;
 } with sexp
 
 (* state machine of the server *)

--- a/lib/state.ml
+++ b/lib/state.ml
@@ -94,7 +94,9 @@ type server_handshake_state =
   | AwaitClientKeyExchange_DHE_RSA of session_data * dh_sent * hs_log (* server hello done is sent, and DHE_RSA key exchange used, waiting for client key exchange *)
   | AwaitClientCertificateVerify of session_data * crypto_context * crypto_context * hs_log
   | AwaitClientChangeCipherSpec of session_data * crypto_context * crypto_context * hs_log (* client key exchange received, next should be change cipher spec *)
+  | AwaitClientChangeCipherSpecResume of session_data * crypto_context * Cstruct.t * hs_log (* resumption: next should be change cipher spec *)
   | AwaitClientFinished of session_data * hs_log (* change cipher spec received, next should be the finished including a hmac over all handshake packets *)
+  | AwaitClientFinishedResume of session_data * Cstruct.t * hs_log (* change cipher spec received, next should be the finished including a hmac over all handshake packets *)
   | Established (* handshake successfully completed *)
   with sexp
 
@@ -109,7 +111,9 @@ type client_handshake_state =
   | AwaitCertificateRequestOrServerHelloDone of session_data * Cstruct.t * Cstruct.t * hs_log (* server hello done expected, client key exchange and premastersecret are ready *)
   | AwaitServerHelloDone of session_data * (Hash.hash * Packet.signature_algorithm_type) list option * Cstruct.t * Cstruct.t * hs_log (* server hello done expected, client key exchange and premastersecret are ready *)
   | AwaitServerChangeCipherSpec of session_data * crypto_context * Cstruct.t * hs_log (* change cipher spec expected *)
+  | AwaitServerChangeCipherSpecResume of session_data * crypto_context * crypto_context * hs_log (* change cipher spec expected *)
   | AwaitServerFinished of session_data * Cstruct.t * hs_log (* finished expected with a hmac over all handshake packets *)
+  | AwaitServerFinishedResume of session_data * hs_log (* finished expected with a hmac over all handshake packets *)
   | Established (* handshake successfully completed *)
   with sexp
 

--- a/mirage/example2/config.ml
+++ b/mirage/example2/config.ml
@@ -11,12 +11,13 @@ let () =
   add_to_opam_packages [
     "mirage-clock-unix" ;
     "mirage-http" ;
+    "tcpip" ;
     "channel"
   ] ;
   add_to_ocamlfind_libraries [
     "mirage-clock-unix" ;
     "tls"; "tls.mirage" ;
-    "tcpip" ; "channel" ;
+    "tcpip"; "channel" ;
     "cohttp.lwt-core" ;
     "mirage-http"
   ] ;


### PR DESCRIPTION
This adds support for session resumption. The user-facing change is that both `Config.client` and `Config.client` have a callback parameter `session_cache : Cstruct.t option -> epoch_data option`. A client uses the session id from `session_cache None` in its initial client hello. A server resumes a session if the id is found in the cache.

The cache may be filled by a user by using the `epoch_data` (exposed from `Engine.epoch : state -> epoch_data`) and inserting it into a cache, using its `sessionid` as key.

Internal cleanups: `epoch_data` moved to `Core` module; `Handshake_crypto` has `derive_master_secret` and `initialise_crypto_context` separated. Bot the client and the server state machine have two new states, waiting for CCS/Finished from the other side during resumption. Both `session_data` and `epoch_data` now contain a `sessionid` field. `sever_hello` is a top-level function in `Handshake_server`, which produces a server hello (analogue to `default_client_hello`).

While doing a renegotiation we do not do resumption: if someone request new symmetric key material, reusing the same and just running the KDF is useless (since if master_secret is compromised, all input to it (server_random, client_random transmitted over the wire) is known.