### PR TITLE
Implied entropy for Lwt

### DIFF
--- a/design.md
+++ b/design.md
@@ -232,8 +232,6 @@ number of bytes read. The surrounding module, `Tls_lwt`, provides a simpler,
 
 ```OCaml
 let main host port =
-  Nocrypto_entropy_lwt.initialize ()
-  >>
   lwt authenticator = X509_lwt.authenticator (`Ca_dir nss_trusted_ca_dir) in
   lwt (ic, oc)      = Tls_lwt.connect ~authenticator (host, port) in
   let req = String.concat "\r\n" [

--- a/lwt/examples/echo_client.ml
+++ b/lwt/examples/echo_client.ml
@@ -3,8 +3,6 @@ open Ex_common
 open Lwt
 
 let echo_client ?ca host port =
-  Nocrypto_entropy_lwt.initialize () >>
-
   let open Lwt_io in
 
   let port          = int_of_string port in

--- a/lwt/examples/echo_server.ml
+++ b/lwt/examples/echo_server.ml
@@ -58,7 +58,6 @@ let serve_ssl port callback =
     loop (server_s ())
 
 let echo_server port =
-  Nocrypto_entropy_lwt.initialize () >>
   serve_ssl port @@ fun (ic, oc) addr ->
     lines ic |> Lwt_stream.iter_s (fun line ->
       yap "handler" ("+ " ^ line) >> Lwt_io.write_line oc line)

--- a/lwt/examples/echo_server_sni.ml
+++ b/lwt/examples/echo_server_sni.ml
@@ -53,7 +53,6 @@ let serve_ssl port callback =
 
 
 let echo_server port =
-  Nocrypto_entropy_lwt.initialize () >>
   serve_ssl port @@ fun host (ic, oc) addr ->
     lines ic |> Lwt_stream.iter_s (fun line ->
       yap ("handler " ^ host) ("+ " ^ line) >> Lwt_io.write_line oc line)

--- a/lwt/examples/http_client.ml
+++ b/lwt/examples/http_client.ml
@@ -3,7 +3,6 @@ open Lwt
 open Ex_common
 
 let http_client ?ca ?fp host port =
-  Nocrypto_entropy_lwt.initialize () >>
   let port          = int_of_string port in
   lwt authenticator = X509_lwt.authenticator
     ( match ca, fp with

--- a/lwt/examples/starttls_server.ml
+++ b/lwt/examples/starttls_server.ml
@@ -54,7 +54,6 @@ let start_server () =
       write oc (tag ^ ok_starttls) >>
       Lwt_io.close ic >>= fun () ->
       Lwt_io.close oc >>= fun () ->
-      Nocrypto_entropy_lwt.initialize () >>= fun () ->
       cert () >>= fun cert ->
       Tls_lwt.Unix.server_of_fd 
        (Tls.Config.server ~certificates:(`Single cert) ()) sock_cl >>= fun s ->

--- a/lwt/examples/test_client.ml
+++ b/lwt/examples/test_client.ml
@@ -3,7 +3,6 @@ open Lwt
 open Ex_common
 
 let test_client _ =
-  Nocrypto_entropy_lwt.initialize () >>
   let port = 4433 in
   let host = "127.0.0.1" in
   lwt authenticator = X509_lwt.authenticator `No_authentication_I'M_STUPID in

--- a/lwt/examples/test_server.ml
+++ b/lwt/examples/test_server.ml
@@ -33,7 +33,6 @@ let serve_ssl port callback =
 
 
 let test_server port =
-  Nocrypto_entropy_lwt.initialize () >>
   serve_ssl port @@ fun (ic, oc) addr ->
     Lwt_io.read_line ic >>= fun line ->
     yap "handler" ("+ " ^ line)

--- a/lwt/tls_lwt.ml
+++ b/lwt/tls_lwt.ml
@@ -245,3 +245,7 @@ let accept ?trace certificate =
 and connect ?trace authenticator addr =
   let config = Tls.Config.client ~authenticator ()
   in connect_ext ?trace config addr
+
+
+(* Boot the entropy loop at module init time. *)
+let () = ignore @@ Nocrypto_entropy_lwt.initialize ()


### PR DESCRIPTION
Since the previous design was untenable, I made sure entropy init is actually completed *synchronously* ([docs](https://github.com/mirleft/ocaml-nocrypto/blob/master/lwt/nocrypto_entropy_lwt.mli#L10)). This means that we can **FINALLY** internalize entropy init and people can just forget about the whole thing.