### PR TITLE
expose own_random and peer_random in epoch_data

### DIFF
--- a/lib/core.ml
+++ b/lib/core.ml
@@ -163,9 +163,11 @@ type master_secret = Cstruct.t with sexp
 type epoch_data = {
   protocol_version : tls_version ;
   ciphersuite      : Ciphersuite.ciphersuite ;
+  peer_random      : Cstruct.t ;
   peer_certificate : X509.t list ;
   peer_name        : string option ;
   trust_anchor     : X509.t option ;
+  own_random       : Cstruct.t ;
   own_certificate  : X509.t list ;
   own_private_key  : Nocrypto.Rsa.priv option ;
   own_name         : string option ;

--- a/lib/engine.ml
+++ b/lib/engine.ml
@@ -568,12 +568,19 @@ let epoch state =
   match hs.session with
   | []           -> `InitialEpoch
   | session :: _ ->
+     let own_random , peer_random =
+       match hs.machina with
+       | Client _ -> session.client_random , session.server_random
+       | Server _ -> session.server_random , session.client_random
+     in
      `Epoch {
         protocol_version = hs.protocol_version ;
         ciphersuite      = session.ciphersuite ;
+        peer_random ;
         peer_certificate = session.peer_certificate ;
         peer_name        = Config.(hs.config.peer_name) ;
         trust_anchor     = session.trust_anchor ;
+        own_random ;
         own_certificate  = session.own_certificate ;
         own_private_key  = session.own_private_key ;
         own_name         = session.own_name ;


### PR DESCRIPTION
Expose `client_random` and `server_random` from `lib/state.ml` to allow extracting the authenticated timestamp from a remote party:

```ocaml
type session_data = {
  server_random    : Cstruct.t ; (* 32 bytes random from the server hello *)
  client_random    : Cstruct.t ; (* 32 bytes random from the client hello *)
  (* [...] *)
}
```

in `epoch_data` as `own_random` and `peer_random`, see `lib/engine.mli` ->
```ocaml
val epoch : (state : State.state) -> (epoch : epoch_data)`