### PR TITLE
block while renegotiation is in progress, fixes #140

### DIFF
--- a/lib/engine.mli
+++ b/lib/engine.mli
@@ -138,10 +138,6 @@ val handle_tls           : state -> Cstruct.t -> ret
     connection has already completed a handshake. *)
 val can_handle_appdata    : state -> bool
 
-(** [handshake_in_progress tls] is a predicate which indicates whether
-    a handshake is in progress. *)
-val handshake_in_progress : state -> bool
-
 (** [send_application_data tls outs] is [(tls' * out) option] where
     [tls'] is the new tls state, and [out] the cstruct to send over the
     wire (encrypted [outs]). *)

--- a/lwt/tls_lwt.ml
+++ b/lwt/tls_lwt.ml
@@ -158,8 +158,10 @@ module Unix = struct
     | `Eof        -> fail @@ Invalid_argument "tls: closed socket"
     | `Active tls ->
         match tracing t @@ fun () -> Tls.Engine.reneg tls with
-        | None -> fail @@ Invalid_argument "tls: can't rekey: handshake in progress"
-        | Some (tls', buf) -> t.state <- `Active tls' ; write_t t buf
+        | None -> fail @@ Invalid_argument "tls: can't renegotiate"
+        | Some (tls', buf) ->
+           t.state <- `Active tls' ;
+           write_t t buf >> drain_handshake t >> return_unit
 
   let close_tls t =
     match t.state with

--- a/mirage/tls_mirage.ml
+++ b/mirage/tls_mirage.ml
@@ -140,7 +140,9 @@ module Make (F : V1_LWT.FLOW) = struct
             invalid_arg "Renegotiation already in progress"
         | Some (tls', buf) ->
             flow.state <- `Active tls' ;
-            FLOW.write flow.flow buf >|= lift_result
+            match_lwt FLOW.write flow.flow buf >> drain_handshake flow with
+            | `Ok _                -> return (`Ok ())
+            | `Error _ | `Eof as e -> return e
 
   let close flow =
     match flow.state with


### PR DESCRIPTION
The RFC is loose what to do here, but best practises (other stacks) block
while renegotiation is in progress.  This is especially important for triple
handshake attack, more to be read in the thread on the IETF TLS WG
https://www.ietf.org/mail-archive/web/tls/current/msg18313.html .

This also removes the `handshake_in_progress`, which was unused, and considering that `can_handle_appdata` is provided, this should be sufficient.