### PR TITLE
do not hardcode path to certificates and private keys ("tls/"), fixes #294

### DIFF
--- a/mirage/example/sekrit/ca-roots.crt
+++ b/mirage/example/sekrit/ca-roots.crt
@@ -1,0 +1,1 @@
+../../../certificates/ca-root-nss-short.crt

--- a/mirage/example/sekrit/server.key
+++ b/mirage/example/sekrit/server.key
@@ -1,0 +1,1 @@
+../../../certificates/server.key

--- a/mirage/example/sekrit/server.pem
+++ b/mirage/example/sekrit/server.pem
@@ -1,0 +1,1 @@
+../../../certificates/server.pem

--- a/mirage/example/sekrit/tls/ca-roots.crt
+++ b/mirage/example/sekrit/tls/ca-roots.crt
@@ -1,1 +1,0 @@
-../../../../certificates/ca-root-nss-short.crt

--- a/mirage/example/sekrit/tls/server.key
+++ b/mirage/example/sekrit/tls/server.key
@@ -1,1 +1,0 @@
-../../../../certificates/server.key

--- a/mirage/example/sekrit/tls/server.pem
+++ b/mirage/example/sekrit/tls/server.pem
@@ -1,1 +1,0 @@
-../../../../certificates/server.pem

--- a/mirage/example2/sekrit/server.key
+++ b/mirage/example2/sekrit/server.key
@@ -1,0 +1,1 @@
+../../../certificates/server.key

--- a/mirage/example2/sekrit/server.pem
+++ b/mirage/example2/sekrit/server.pem
@@ -1,0 +1,1 @@
+../../../certificates/server.pem

--- a/mirage/example2/sekrit/tls/server.key
+++ b/mirage/example2/sekrit/tls/server.key
@@ -1,1 +1,0 @@
-../../../../certificates/server.key

--- a/mirage/example2/sekrit/tls/server.pem
+++ b/mirage/example2/sekrit/tls/server.pem
@@ -1,1 +1,0 @@
-../../../../certificates/server.pem

--- a/mirage/tls_mirage.ml
+++ b/mirage/tls_mirage.ml
@@ -199,10 +199,7 @@ end
 
 module X509 (KV : V1_LWT.KV_RO) (C : V1.CLOCK) = struct
 
-  let (</>) p1 p2 = p1 ^ "/" ^ p2
-
-  let path          = "tls"
-  let ca_roots_file = path </> "ca-roots.crt"
+  let ca_roots_file = "ca-roots.crt"
   let default_cert  = "server"
 
   let (>>==) a f =
@@ -229,9 +226,9 @@ module X509 (KV : V1_LWT.KV_RO) (C : V1.CLOCK) = struct
   let certificate kv =
     let read name =
       lwt certs =
-        read_full kv (path </> name ^ ".pem") >|= Certificate.of_pem_cstruct
+        read_full kv (name ^ ".pem") >|= Certificate.of_pem_cstruct
       and pk =
-        read_full kv (path </> name ^ ".key") >|= fun pem ->
+        read_full kv (name ^ ".key") >|= fun pem ->
         match Private_key.of_pem_cstruct1 pem with
         | `RSA key -> key
       in


### PR DESCRIPTION
this is certainly a breaking API change and all earlier mirage applications
will break, but forcing a "tls/" path in the store is imho bad.