### PR TITLE
allow resumption if either no renegotiation OR extended master secret

### DIFF
--- a/lib/handshake_client.ml
+++ b/lib/handshake_client.ml
@@ -67,7 +67,7 @@ let answer_server_hello state ch (sh : server_hello) raw log =
   let epoch_matches (epoch : epoch_data) =
     epoch.ciphersuite = sh.ciphersuites &&
       epoch.protocol_version = sh.version &&
-        option false ((=) epoch.session_id) sh.sessionid &&
+        option false (SessionID.equal epoch.session_id) sh.sessionid &&
           (not cfg.use_reneg ||
              (List.mem ExtendedMasterSecret sh.extensions && epoch.extended_ms))
   in
@@ -82,7 +82,7 @@ let answer_server_hello state ch (sh : server_hello) raw log =
                   }
     in
     let client_ctx, server_ctx =
-      Handshake_crypto.initialise_crypto_ctx state.protocol_version session
+      Handshake_crypto.initialise_crypto_ctx sh.version session
     in
     let machina = AwaitServerChangeCipherSpecResume (session, client_ctx, server_ctx, log @ [raw]) in
     ({ state with protocol_version = sh.version ; machina = Client machina }, [])

--- a/lib/handshake_server.ml
+++ b/lib/handshake_server.ml
@@ -325,8 +325,8 @@ let answer_client_hello state (ch : client_hello) raw =
       let cciphers = filter_map ~f:Ciphersuite.any_ciphersuite_to_ciphersuite ciphers in
       List.mem epoch.ciphersuite cciphers &&
         version = epoch.protocol_version &&
-          List.mem ExtendedMasterSecret extensions &&
-            epoch.extended_ms
+          (not state.config.use_reneg ||
+             (List.mem ExtendedMasterSecret extensions && epoch.extended_ms))
     in
 
     match option None state.config.session_cache ch.sessionid with


### PR DESCRIPTION
previously, this was only allowed if the extended master secret was provided
(followup of #300, which includes reasoning)