### PR TITLE
X.509 updates for path building:

### DIFF
--- a/lib/core.ml
+++ b/lib/core.ml
@@ -169,17 +169,19 @@ type master_secret = Cstruct.t with sexp
 
 (** information about an open session *)
 type epoch_data = {
-  protocol_version : tls_version ;
-  ciphersuite      : Ciphersuite.ciphersuite ;
-  peer_random      : Cstruct.t ;
-  peer_certificate : X509.t list ;
-  peer_name        : string option ;
-  trust_anchor     : X509.t option ;
-  own_random       : Cstruct.t ;
-  own_certificate  : X509.t list ;
-  own_private_key  : Nocrypto.Rsa.priv option ;
-  own_name         : string option ;
-  master_secret    : master_secret ;
-  session_id       : SessionID.t ;
-  extended_ms      : bool ;
+  protocol_version       : tls_version ;
+  ciphersuite            : Ciphersuite.ciphersuite ;
+  peer_random            : Cstruct.t ;
+  peer_certificate_chain : X509.t list ;
+  peer_certificate       : X509.t option ;
+  peer_name              : string option ;
+  trust_anchor           : X509.t option ;
+  received_certificates  : X509.t list ;
+  own_random             : Cstruct.t ;
+  own_certificate        : X509.t list ;
+  own_private_key        : Nocrypto.Rsa.priv option ;
+  own_name               : string option ;
+  master_secret          : master_secret ;
+  session_id             : SessionID.t ;
+  extended_ms            : bool ;
 } with sexp

--- a/lib/engine.ml
+++ b/lib/engine.ml
@@ -12,9 +12,7 @@ type fatal = State.fatal
 type failure = State.failure with sexp
 
 let alert_of_authentication_failure = function
-  | `SelfSigned _ -> Packet.UNKNOWN_CA
-  | `NoTrustAnchor -> Packet.UNKNOWN_CA
-  | `CertificateExpired _ -> Packet.CERTIFICATE_EXPIRED
+  | `Leaf (`LeafCertificateExpired _) -> Packet.CERTIFICATE_EXPIRED
   | _ -> Packet.BAD_CERTIFICATE
 
 let alert_of_error = function
@@ -569,17 +567,19 @@ let epoch state =
        | Server _ -> session.server_random , session.client_random
      in
      `Epoch {
-        protocol_version = hs.protocol_version ;
-        ciphersuite      = session.ciphersuite ;
+        protocol_version       = hs.protocol_version ;
+        ciphersuite            = session.ciphersuite ;
         peer_random ;
-        peer_certificate = session.peer_certificate ;
-        peer_name        = Config.(hs.config.peer_name) ;
-        trust_anchor     = session.trust_anchor ;
+        peer_certificate       = session.peer_certificate ;
+        peer_certificate_chain = session.peer_certificate_chain ;
+        peer_name              = Config.(hs.config.peer_name) ;
+        trust_anchor           = session.trust_anchor ;
         own_random ;
-        own_certificate  = session.own_certificate ;
-        own_private_key  = session.own_private_key ;
-        own_name         = session.own_name ;
-        master_secret    = session.master_secret ;
-        session_id       = session.session_id ;
-        extended_ms      = session.extended_ms ;
+        own_certificate        = session.own_certificate ;
+        own_private_key        = session.own_private_key ;
+        own_name               = session.own_name ;
+        received_certificates  = session.received_certificates ;
+        master_secret          = session.master_secret ;
+        session_id             = session.session_id ;
+        extended_ms            = session.extended_ms ;
       }

--- a/lib/state.ml
+++ b/lib/state.ml
@@ -69,20 +69,22 @@ type reneg_params = Cstruct.t * Cstruct.t
   with sexp
 
 type session_data = {
-  server_random    : Cstruct.t ; (* 32 bytes random from the server hello *)
-  client_random    : Cstruct.t ; (* 32 bytes random from the client hello *)
-  client_version   : tls_any_version ; (* version in client hello (needed in RSA client key exchange) *)
-  ciphersuite      : Ciphersuite.ciphersuite ;
-  peer_certificate : X509.t list ;
-  trust_anchor     : X509.t option ;
-  own_certificate  : X509.t list ;
-  own_private_key  : Nocrypto.Rsa.priv option ;
-  master_secret    : master_secret ;
-  renegotiation    : reneg_params ; (* renegotiation data *)
-  own_name         : string option ;
-  client_auth      : bool ;
-  session_id       : Cstruct.t ;
-  extended_ms      : bool ;
+  server_random          : Cstruct.t ; (* 32 bytes random from the server hello *)
+  client_random          : Cstruct.t ; (* 32 bytes random from the client hello *)
+  client_version         : tls_any_version ; (* version in client hello (needed in RSA client key exchange) *)
+  ciphersuite            : Ciphersuite.ciphersuite ;
+  peer_certificate_chain : X509.t list ;
+  peer_certificate       : X509.t option ;
+  trust_anchor           : X509.t option ;
+  received_certificates  : X509.t list ;
+  own_certificate        : X509.t list ;
+  own_private_key        : Nocrypto.Rsa.priv option ;
+  master_secret          : master_secret ;
+  renegotiation          : reneg_params ; (* renegotiation data *)
+  own_name               : string option ;
+  client_auth            : bool ;
+  session_id             : Cstruct.t ;
+  extended_ms            : bool ;
 } with sexp
 
 (* state machine of the server *)


### PR DESCRIPTION
- returned failures are different
- preserve more in the epoch_data:
 - peer_certificate (t option)
 - received_certificates (t list)
 - peer_certificate_chain (t list)
 - trust_anchor (t option)