### PR TITLE
unify return type of hanshake and ccs

### DIFF
--- a/lib/engine.ml
+++ b/lib/engine.ml
@@ -334,18 +334,18 @@ let handle_packet hs buf = function
 
   | Packet.ALERT ->
       Alert.handle buf >|= fun (err, out) ->
-        (hs, out, None, `Pass, err)
+        (hs, out, None, err)
 
   | Packet.APPLICATION_DATA ->
     if hs_can_handle_appdata hs then
       (Tracing.cs ~tag:"application-data-in" buf;
-       return (hs, [], non_empty buf, `Pass, `No_err))
+       return (hs, [], non_empty buf, `No_err))
     else
       fail (`Fatal `CannotHandleApplicationDataYet)
 
   | Packet.CHANGE_CIPHER_SPEC ->
       handle_change_cipher_spec hs.machina hs buf
-      >|= fun (hs, items, dec_cmd) -> (hs, items, None, dec_cmd, `No_err)
+      >|= fun (hs, items) -> (hs, items, None, `No_err)
 
   | Packet.HANDSHAKE ->
      separate_handshakes (hs.hs_fragment <+> buf)
@@ -355,7 +355,7 @@ let handle_packet hs buf = function
          >|= fun (hs', items') -> (hs', items @ items'))
        (hs, []) hss
      >|= fun (hs, items) ->
-       ({ hs with hs_fragment }, items, None, `Pass, `No_err)
+       ({ hs with hs_fragment }, items, None, `No_err)
 
   | Packet.HEARTBEAT -> fail (`Fatal `NoHeartbeat)
 
@@ -376,19 +376,17 @@ let handle_raw_record state (hdr, buf as record : raw_record) =
   decrypt version state.decryptor hdr.content_type buf
   >>= fun (dec_st, dec) ->
   handle_packet state.handshake dec hdr.content_type
-  >|= fun (handshake, items, data, dec_cmd, err) ->
-  let (encryptor, encs) =
-    List.fold_left (fun (st, es) -> function
-      | `Change_enc st' -> (st', es)
+  >|= fun (handshake, items, data, err) ->
+  let (encryptor, decryptor, encs) =
+    List.fold_left (fun (enc, dec, es) -> function
+      | `Change_enc enc' -> (enc', dec, es)
+      | `Change_dec dec' -> (enc, dec', es)
       | `Record r       ->
-          let (st', enc) = encrypt_records st handshake.protocol_version [r] in
-          (st', es @ enc))
-    (state.encryptor, [])
+          let (enc', encbuf) = encrypt_records enc handshake.protocol_version [r] in
+          (enc', dec, es @ encbuf))
+    (state.encryptor, dec_st, [])
     items
   in
-  let decryptor = match dec_cmd with
-    | `Change_dec dec -> dec
-    | `Pass           -> dec_st in
   let state' = { state with handshake ; encryptor ; decryptor } in
 
   Tracing.sexpfs ~tag:"record-out" ~f:sexp_of_record encs ;

--- a/lib/handshake_client.ml
+++ b/lib/handshake_client.ml
@@ -356,7 +356,7 @@ let handle_change_cipher_spec cs state packet =
      guard (Cs.null state.hs_fragment) (`Fatal `HandshakeFragmentsNotEmpty) >|= fun () ->
      let machina = AwaitServerFinished (session, client_verify, log) in
      Tracing.cs ~tag:"change-cipher-spec-in" packet ;
-     ({ state with machina = Client machina }, [], `Change_dec (Some server_ctx))
+     ({ state with machina = Client machina }, [`Change_dec (Some server_ctx)])
   | Or_error.Ok (), AwaitServerChangeCipherSpecResume (session, client_ctx, server_ctx, log) ->
      guard (Cs.null state.hs_fragment) (`Fatal `HandshakeFragmentsNotEmpty) >|= fun () ->
      let ccs = change_cipher_spec in
@@ -364,8 +364,7 @@ let handle_change_cipher_spec cs state packet =
      Tracing.cs ~tag:"change-cipher-spec-in" packet ;
      Tracing.cs ~tag:"change-cipher-spec-out" packet ;
      ({ state with machina = Client machina },
-      [`Record ccs ; `Change_enc (Some client_ctx)],
-      `Change_dec (Some server_ctx))
+      [`Record ccs ; `Change_enc (Some client_ctx); `Change_dec (Some server_ctx)])
   | Or_error.Error re, _ -> fail (`Fatal (`ReaderError re))
   | _ -> fail (`Fatal `UnexpectedCCS)
 

--- a/lib/handshake_client.mli
+++ b/lib/handshake_client.mli
@@ -2,6 +2,6 @@ open Core
 open State
 
 val default_client_hello : Config.config -> (client_hello * tls_version)
-val handle_change_cipher_spec : client_handshake_state -> handshake_state -> Cstruct.t -> ccs_return or_error
+val handle_change_cipher_spec : client_handshake_state -> handshake_state -> Cstruct.t -> handshake_return or_error
 val handle_handshake : client_handshake_state -> handshake_state -> Cstruct.t -> handshake_return or_error
 val answer_hello_request : handshake_state -> handshake_return or_error

--- a/lib/handshake_server.ml
+++ b/lib/handshake_server.ml
@@ -425,8 +425,7 @@ let handle_change_cipher_spec ss state packet =
      Tracing.cs ~tag:"change-cipher-spec-out" packet ;
 
      return ({ state with machina = Server machina },
-             [`Record ccs; `Change_enc (Some server_ctx)],
-             `Change_dec (Some client_ctx))
+             [`Record ccs; `Change_enc (Some server_ctx); `Change_dec (Some client_ctx)])
   | Or_error.Ok (), AwaitClientChangeCipherSpecResume (session, client_ctx, server_verify, log) ->
      guard (Cs.null state.hs_fragment) (`Fatal `HandshakeFragmentsNotEmpty) >|= fun () ->
      let machina = AwaitClientFinishedResume (session, server_verify, log)
@@ -435,7 +434,7 @@ let handle_change_cipher_spec ss state packet =
      Tracing.cs ~tag:"change-cipher-spec-out" packet ;
 
      ({ state with machina = Server machina },
-      [], `Change_dec (Some client_ctx))
+      [`Change_dec (Some client_ctx)])
   | Or_error.Error er, _ -> fail (`Fatal (`ReaderError er))
   | _ -> fail (`Fatal `UnexpectedCCS)
 

--- a/lib/handshake_server.mli
+++ b/lib/handshake_server.mli
@@ -3,5 +3,5 @@ open State
 
 val hello_request : handshake_state -> handshake_return or_error
 
-val handle_change_cipher_spec : server_handshake_state -> handshake_state -> Cstruct.t -> ccs_return or_error
+val handle_change_cipher_spec : server_handshake_state -> handshake_state -> Cstruct.t -> handshake_return or_error
 val handle_handshake : server_handshake_state -> handshake_state -> Cstruct.t -> handshake_return or_error

--- a/lib/state.ml
+++ b/lib/state.ml
@@ -144,20 +144,12 @@ type record = Packet.content_type * Cstruct.t with sexp
 (* response returned by a handler *)
 type rec_resp = [
   | `Change_enc of crypto_state (* either instruction to change the encryptor to the given one *)
-  | `Record     of record (* or a record which should be sent out *)
-]
-
-(* response for the decryption part *)
-type dec_resp = [
   | `Change_dec of crypto_state (* either change the decryptor to the given one *)
-  | `Pass (* do not change anything *)
+  | `Record     of record (* or a record which should be sent out *)
 ]
 
 (* return type of handshake handlers *)
 type handshake_return = handshake_state * rec_resp list
-
-(* return type of change cipher spec handlers *)
-type ccs_return = handshake_state * rec_resp list * dec_resp
 
 (* Top level state, encapsulating the entire session. *)
 type state = {


### PR DESCRIPTION
- allows handshake to modify decryptor (required for TLS 1.3)