### PR TITLE
Separate client and server extensions

### DIFF
--- a/lib/core.ml
+++ b/lib/core.ml
@@ -99,11 +99,6 @@ type client_hello = (any_ciphersuite list, tls_any_version) hello
 type server_hello = (ciphersuite, tls_version) hello
   with sexp
 
-type rsa_parameters = {
-  rsa_modulus  : Cstruct.t;
-  rsa_exponent : Cstruct.t;
-} with sexp
-
 type dh_parameters = {
   dh_p  : Cstruct.t;
   dh_g  : Cstruct.t;

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -73,24 +73,33 @@ module SessionID = struct
   let equal = Cstruct.equal
 end
 
-type extension =
-  | Hostname of string option
-  | MaxFragmentLength of max_fragment_length
-  | EllipticCurves of named_curve_type list
-  | ECPointFormats of ec_point_format list
-  | SecureRenegotiation of Cstruct.t
-  | Padding of int
-  | SignatureAlgorithms of (Hash.hash * signature_algorithm_type) list
-  | UnknownExtension of (int * Cstruct.t)
-  | ExtendedMasterSecret
-  with sexp
+type client_extension = [
+  | `Hostname of string
+  | `MaxFragmentLength of max_fragment_length
+  | `EllipticCurves of named_curve_type list
+  | `ECPointFormats of ec_point_format list
+  | `SecureRenegotiation of Cstruct.t
+  | `Padding of int
+  | `SignatureAlgorithms of (Hash.hash * signature_algorithm_type) list
+  | `UnknownExtension of (int * Cstruct.t)
+  | `ExtendedMasterSecret
+] with sexp
+
+type server_extension = [
+  | `Hostname
+  | `MaxFragmentLength of max_fragment_length
+  | `ECPointFormats of ec_point_format list
+  | `SecureRenegotiation of Cstruct.t
+  | `UnknownExtension of (int * Cstruct.t)
+  | `ExtendedMasterSecret
+] with sexp
 
 type client_hello = {
   client_version : tls_any_version;
   client_random  : Cstruct.t;
   sessionid      : SessionID.t option;
   ciphersuites   : any_ciphersuite list;
-  extensions     : extension list
+  extensions     : client_extension list
 } with sexp
 
 type server_hello = {
@@ -98,7 +107,7 @@ type server_hello = {
   server_random  : Cstruct.t;
   sessionid      : SessionID.t option;
   ciphersuite    : ciphersuite;
-  extensions     : extension list
+  extensions     : server_extension list
 } with sexp
 
 type dh_parameters = {

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -85,19 +85,21 @@ type extension =
   | ExtendedMasterSecret
   with sexp
 
-type ('a, 'b) hello = {
-  version      : 'b;
-  random       : Cstruct.t;
-  sessionid    : SessionID.t option;
-  ciphersuites : 'a;
-  extensions   : extension list
+type client_hello = {
+  client_version : tls_any_version;
+  client_random  : Cstruct.t;
+  sessionid      : SessionID.t option;
+  ciphersuites   : any_ciphersuite list;
+  extensions     : extension list
 } with sexp
 
-type client_hello = (any_ciphersuite list, tls_any_version) hello
-  with sexp
-
-type server_hello = (ciphersuite, tls_version) hello
-  with sexp
+type server_hello = {
+  server_version : tls_version;
+  server_random  : Cstruct.t;
+  sessionid      : SessionID.t option;
+  ciphersuite    : ciphersuite;
+  extensions     : extension list
+} with sexp
 
 type dh_parameters = {
   dh_p  : Cstruct.t;

--- a/lib/engine.ml
+++ b/lib/engine.ml
@@ -510,7 +510,7 @@ let client config =
    implementations reliably ignore unknown cipher suites, the SCSV may
    be safely sent to any server. *)
     | TLS_1_0 -> ([Packet.TLS_EMPTY_RENEGOTIATION_INFO_SCSV], [])
-    | TLS_1_1 | TLS_1_2 -> ([], [SecureRenegotiation (Cstruct.create 0)])
+    | TLS_1_1 | TLS_1_2 -> ([], [`SecureRenegotiation (Cstruct.create 0)])
   in
 
   let client_hello =

--- a/lib/reader.ml
+++ b/lib/reader.ml
@@ -232,7 +232,28 @@ let parse_hash_sig buf =
   else
     parse_count_list parsef (shift buf 2) [] (count / 2)
 
-let parse_extension raw =
+let parse_extension buf = function
+  | MAX_FRAGMENT_LENGTH ->
+     (match parse_fragment_length buf with
+      | Some mfl -> `MaxFragmentLength mfl
+      | None     -> raise_unknown "maximum fragment length")
+  | EC_POINT_FORMATS ->
+       let formats = parse_ec_point_format buf in
+       `ECPointFormats formats
+  | RENEGOTIATION_INFO ->
+       let len' = get_uint8 buf 0 in
+       if len buf <> len' + 1 then
+         raise_trailing_bytes "renegotiation"
+       else
+         `SecureRenegotiation (sub buf 1 len')
+  | EXTENDED_MASTER_SECRET ->
+      if len buf > 0 then
+         raise_trailing_bytes "extended master secret"
+       else
+         `ExtendedMasterSecret
+  | x -> `UnknownExtension (extension_type_to_int x, buf)
+
+let parse_client_extension raw =
   let etype = BE.get_uint16 raw 0 in
   let length = BE.get_uint16 raw 2 in
   let buf = sub raw 4 length in
@@ -240,28 +261,14 @@ let parse_extension raw =
     match int_to_extension_type etype with
     | Some SERVER_NAME ->
        (match parse_hostnames buf with
-        | []     -> Hostname None
-        | [name] -> Hostname (Some name)
+        | [name] -> `Hostname name
         | _      -> raise_unknown "bad server name indication (multiple names)")
-    | Some MAX_FRAGMENT_LENGTH ->
-       (match parse_fragment_length buf with
-        | Some mfl -> MaxFragmentLength mfl
-        | None     -> raise_unknown "maximum fragment length")
     | Some ELLIPTIC_CURVES ->
        let ecc = parse_elliptic_curves buf in
-       EllipticCurves ecc
-    | Some EC_POINT_FORMATS ->
-       let formats = parse_ec_point_format buf in
-       ECPointFormats formats
-    | Some RENEGOTIATION_INFO ->
-       let len' = get_uint8 buf 0 in
-       if len buf <> len' + 1 then
-         raise_trailing_bytes "renegotiation"
-       else
-         SecureRenegotiation (sub buf 1 len')
+       `EllipticCurves ecc
     | Some PADDING ->
        let rec check = function
-         | 0 -> Padding length
+         | 0 -> `Padding length
          | n -> let idx = pred n in
                 if get_uint8 buf idx <> 0 then
                   raise_unknown "bad padding in padding extension"
@@ -274,23 +281,35 @@ let parse_extension raw =
        if len rt <> 0 then
          raise_trailing_bytes "signature algorithms"
        else
-         SignatureAlgorithms algos
-    | Some EXTENDED_MASTER_SECRET ->
-      if len buf > 0 then
-         raise_trailing_bytes "extended master secret"
-       else
-         ExtendedMasterSecret
-    | _ ->
-       UnknownExtension (etype, buf)
+         `SignatureAlgorithms algos
+    | Some x -> parse_extension buf x
+    | None -> `UnknownExtension (etype, buf)
   in
   (Some data, shift raw (4 + length))
 
-let parse_extensions buf =
+let parse_server_extension raw =
+  let etype = BE.get_uint16 raw 0 in
+  let length = BE.get_uint16 raw 2 in
+  let buf = sub raw 4 length in
+  let data =
+    match int_to_extension_type etype with
+    | Some SERVER_NAME ->
+       (match parse_hostnames buf with
+        | [] -> `Hostname
+        | _      -> raise_unknown "bad server name indication (multiple names)")
+    | Some ELLIPTIC_CURVES | Some SIGNATURE_ALGORITHMS | Some PADDING ->
+       raise_unknown "invalid extension in server hello!"
+    | Some x -> parse_extension buf x
+    | None -> `UnknownExtension (etype, buf)
+  in
+  (Some data, shift raw (4 + length))
+
+let parse_extensions parse_ext buf =
   let length = BE.get_uint16 buf 0 in
   if len buf <> length + 2 then
     raise_trailing_bytes "extensions"
   else
-    parse_list parse_extension (sub buf 2 length) []
+    parse_list parse_ext (sub buf 2 length) []
 
 let parse_client_hello buf =
   let client_version = parse_any_version_exn buf in
@@ -306,7 +325,7 @@ let parse_client_hello buf =
   let extensions = if len rt' == 0 then
                      []
                    else
-                     parse_extensions rt'
+                     parse_extensions parse_client_extension rt'
   in
   ClientHello { client_version ; client_random ; sessionid ; ciphersuites ; extensions }
 
@@ -331,7 +350,7 @@ let parse_server_hello buf =
   let extensions = if len rt' == 0 then
                      []
                    else
-                     parse_extensions rt'
+                     parse_extensions parse_server_extension rt'
   in
   ServerHello { server_version ; server_random ; sessionid ; ciphersuite ; extensions }
 

--- a/lib/writer.ml
+++ b/lib/writer.ml
@@ -179,7 +179,7 @@ let assemble_extensions es =
   assemble_list ~none_if_empty:true Two assemble_extension es
 
 let assemble_client_hello (cl : client_hello) : Cstruct.t =
-  let v = assemble_any_protocol_version cl.version in
+  let v = assemble_any_protocol_version cl.client_version in
   let sid =
     let buf = create 1 in
     match cl.sessionid with
@@ -189,7 +189,7 @@ let assemble_client_hello (cl : client_hello) : Cstruct.t =
   let css = assemble_any_ciphersuites cl.ciphersuites in
   (* compression methods, completely useless *)
   let cms = assemble_compression_methods [NULL] in
-  let bbuf = v <+> cl.random <+> sid <+> css <+> cms in
+  let bbuf = v <+> cl.client_random <+> sid <+> css <+> cms in
   (* some widely deployed firewalls drop ClientHello messages which are
      > 256 and < 511 byte, insert PADDING extension for these *)
   (* from draft-ietf-tls-padding-00:
@@ -225,18 +225,18 @@ let assemble_client_hello (cl : client_hello) : Cstruct.t =
   bbuf <+> extensions <+> extrapadding
 
 let assemble_server_hello (sh : server_hello) : Cstruct.t =
-  let v = assemble_protocol_version sh.version in
+  let v = assemble_protocol_version sh.server_version in
   let sid =
     let buf = create 1 in
     match sh.sessionid with
      | None   -> set_uint8 buf 0 0; buf
      | Some s -> set_uint8 buf 0 (len s); buf <+> s
   in
-  let cs = assemble_ciphersuite sh.ciphersuites in
+  let cs = assemble_ciphersuite sh.ciphersuite in
   (* useless compression method *)
   let cm = assemble_compression_method NULL in
   let extensions = assemble_extensions sh.extensions in
-  let bbuf = v <+> sh.random <+> sid <+> cs <+> cm in
+  let bbuf = v <+> sh.server_random <+> sid <+> cs <+> cm in
   bbuf <+> extensions
 
 let assemble_dh_parameters p =

--- a/tests/readertests.ml
+++ b/tests/readertests.ml
@@ -1136,10 +1136,10 @@ let good_client_hellos =
   (* I rolled the dice 16 times *)
   let rnd = [ 0; 1; 2; 3; 4; 5; 6; 7; 8; 9; 10; 11; 12; 13; 14; 15 ] in
   let rand = rnd @ rnd in
-  let random = list_to_cstruct rand in
+  let client_random = list_to_cstruct rand in
   Core.(let ch : client_hello =
-          { version = Supported TLS_1_2 ;
-            random ;
+          { client_version = Supported TLS_1_2 ;
+            client_random ;
             sessionid = None ;
             ciphersuites = [] ;
             extensions = []}
@@ -1147,11 +1147,11 @@ let good_client_hellos =
         [
           (* versions *)
           ([1; 0; 0; 38; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *)] , ch ) ;
-          ([1; 0; 0; 38; 3; 0] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *)] , { ch with version = SSL_3 } ) ;
-          ([1; 0; 0; 38; 3; 1] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *)] , { ch with version = Supported TLS_1_0 } ) ;
-          ([1; 0; 0; 38; 3; 2] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *)] , { ch with version = Supported TLS_1_1 } ) ;
-          ([1; 0; 0; 38; 3; 4] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *)] , { ch with version = TLS_1_X 4 } ) ;
-          ([1; 0; 0; 38; 3; 5] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *)] , { ch with version = TLS_1_X 5 } ) ;
+          ([1; 0; 0; 38; 3; 0] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *)] , { ch with client_version = SSL_3 } ) ;
+          ([1; 0; 0; 38; 3; 1] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *)] , { ch with client_version = Supported TLS_1_0 } ) ;
+          ([1; 0; 0; 38; 3; 2] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *)] , { ch with client_version = Supported TLS_1_1 } ) ;
+          ([1; 0; 0; 38; 3; 4] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *)] , { ch with client_version = TLS_1_X 4 } ) ;
+          ([1; 0; 0; 38; 3; 5] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *)] , { ch with client_version = TLS_1_X 5 } ) ;
 
           (* well-formed compression (not available in higher layer) *)
           ([1; 0; 0; 39; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 1; 0; (* exts *)] , ch ) ;
@@ -1250,8 +1250,8 @@ let good_client_hellos =
 (*           0x00; 0x23; 0x00; 0x00; (* sessionticket_tls *)
            0x00; 0x0f; 0x00; 0x01; 0x01 (* heartbeat *) *) ,
            { ch with
-             version = Supported TLS_1_0 ;
-             random =  list_to_cstruct [0x7c; 0x53; 0x05; 0x72; 0x7a; 0x1b; 0x84; 0x70; 0x30; 0x89; 0xef; 0xad; 0xfb; 0x56; 0xc1; 0x3d; 0x73; 0x4b; 0xc7; 0xcb; 0x8c; 0xc8; 0x75; 0x43; 0x01; 0x12; 0x32; 0xd6; 0x74; 0x87; 0xcb; 0x18] ;
+             client_version = Supported TLS_1_0 ;
+             client_random =  list_to_cstruct [0x7c; 0x53; 0x05; 0x72; 0x7a; 0x1b; 0x84; 0x70; 0x30; 0x89; 0xef; 0xad; 0xfb; 0x56; 0xc1; 0x3d; 0x73; 0x4b; 0xc7; 0xcb; 0x8c; 0xc8; 0x75; 0x43; 0x01; 0x12; 0x32; 0xd6; 0x74; 0x87; 0xcb; 0x18] ;
              ciphersuites = Packet.([TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA; TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA; TLS_SRP_SHA_DSS_WITH_AES_256_CBC_SHA; TLS_SRP_SHA_RSA_WITH_AES_256_CBC_SHA; TLS_DHE_RSA_WITH_AES_256_CBC_SHA; TLS_DHE_DSS_WITH_AES_256_CBC_SHA; TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA; TLS_DHE_DSS_WITH_CAMELLIA_256_CBC_SHA; TLS_ECDH_RSA_WITH_AES_256_CBC_SHA; TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA; TLS_RSA_WITH_AES_256_CBC_SHA; TLS_RSA_WITH_CAMELLIA_256_CBC_SHA; TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA; TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA; TLS_SRP_SHA_DSS_WITH_3DES_EDE_CBC_SHA; TLS_SRP_SHA_RSA_WITH_3DES_EDE_CBC_SHA; TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA; TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA; TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA; TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA; TLS_RSA_WITH_3DES_EDE_CBC_SHA; TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA; TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA; TLS_SRP_SHA_DSS_WITH_AES_128_CBC_SHA; TLS_SRP_SHA_RSA_WITH_AES_128_CBC_SHA; TLS_DHE_RSA_WITH_AES_128_CBC_SHA; TLS_DHE_DSS_WITH_AES_128_CBC_SHA; TLS_DHE_RSA_WITH_SEED_CBC_SHA; TLS_DHE_DSS_WITH_SEED_CBC_SHA; TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA; TLS_DHE_DSS_WITH_CAMELLIA_128_CBC_SHA; TLS_ECDH_RSA_WITH_AES_128_CBC_SHA; TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA; TLS_RSA_WITH_AES_128_CBC_SHA; TLS_RSA_WITH_SEED_CBC_SHA; TLS_RSA_WITH_CAMELLIA_128_CBC_SHA; TLS_RSA_WITH_IDEA_CBC_SHA; TLS_ECDHE_RSA_WITH_RC4_128_SHA; TLS_ECDHE_ECDSA_WITH_RC4_128_SHA; TLS_ECDH_RSA_WITH_RC4_128_SHA; TLS_ECDH_ECDSA_WITH_RC4_128_SHA; TLS_RSA_WITH_RC4_128_SHA; TLS_RSA_WITH_RC4_128_MD5; TLS_DHE_RSA_WITH_DES_CBC_SHA; TLS_DHE_DSS_WITH_DES_CBC_SHA; TLS_RSA_WITH_DES_CBC_SHA; TLS_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA; TLS_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA; TLS_RSA_EXPORT_WITH_DES40_CBC_SHA; TLS_RSA_EXPORT_WITH_RC2_CBC_40_MD5; TLS_RSA_EXPORT_WITH_RC4_40_MD5; TLS_EMPTY_RENEGOTIATION_INFO_SCSV]);
              extensions = [ECPointFormats Packet.([UNCOMPRESSED; ANSIX962_COMPRESSED_PRIME; ANSIX962_COMPRESSED_CHAR2]) ;
                            EllipticCurves Packet.([SECT571R1; SECT571K1; SECP521R1; SECT409K1; SECT409R1; SECP384R1; SECT283K1; SECT283R1; SECP256K1; SECP256R1; SECT239K1; SECT233K1; SECT233R1; SECP224K1; SECP224R1; SECT193R1; SECT193R2; SECP192K1; SECP192R1; SECT163K1; SECT163R1; SECT163R2; SECP160K1; SECP160R1; SECP160R2]) ] } ) ;
@@ -1289,8 +1289,8 @@ let good_client_hellos =
               0x00; 0x00; 0x00; 0x00; 0x00; 0x00; 0x00; 0x00; 0x00; 0x00; 0x00; 0x00; 0x00; 0x00; 0x00; 0x00;
               0x00; 0x00; 0x00; 0x00; 0x00; 0x00; 0x00; 0x00; 0x00 ],
             { ch with
-              version = Supported TLS_1_2 ;
-              random = list_to_cstruct [0xb7; 0x36; 0xeb; 0x21; 0xec; 0x81; 0x4d; 0x01; 0xfc; 0xf4; 0xe2; 0x06; 0x9a; 0x34; 0xb7; 0x21; 0xe1; 0x23; 0x6f; 0xbe; 0x50; 0xbf; 0xfe; 0x33; 0x9b; 0xc9; 0x5b; 0x20; 0x0e; 0x15; 0x02; 0x27] ;
+              client_version = Supported TLS_1_2 ;
+              client_random = list_to_cstruct [0xb7; 0x36; 0xeb; 0x21; 0xec; 0x81; 0x4d; 0x01; 0xfc; 0xf4; 0xe2; 0x06; 0x9a; 0x34; 0xb7; 0x21; 0xe1; 0x23; 0x6f; 0xbe; 0x50; 0xbf; 0xfe; 0x33; 0x9b; 0xc9; 0x5b; 0x20; 0x0e; 0x15; 0x02; 0x27] ;
               ciphersuites = Packet.([TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384; TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384; TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384; TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384; TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA; TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA; TLS_SRP_SHA_DSS_WITH_AES_256_CBC_SHA; TLS_SRP_SHA_RSA_WITH_AES_256_CBC_SHA; TLS_DHE_DSS_WITH_AES_256_GCM_SHA384; TLS_DHE_RSA_WITH_AES_256_GCM_SHA384; TLS_DHE_RSA_WITH_AES_256_CBC_SHA256; TLS_DHE_DSS_WITH_AES_256_CBC_SHA256; TLS_DHE_RSA_WITH_AES_256_CBC_SHA; TLS_DHE_DSS_WITH_AES_256_CBC_SHA; TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA; TLS_DHE_DSS_WITH_CAMELLIA_256_CBC_SHA; TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384; TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384; TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384; TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384; TLS_ECDH_RSA_WITH_AES_256_CBC_SHA; TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA; TLS_RSA_WITH_AES_256_GCM_SHA384; TLS_RSA_WITH_AES_256_CBC_SHA256; TLS_RSA_WITH_AES_256_CBC_SHA; TLS_RSA_WITH_CAMELLIA_256_CBC_SHA; TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA; TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA; TLS_SRP_SHA_DSS_WITH_3DES_EDE_CBC_SHA; TLS_SRP_SHA_RSA_WITH_3DES_EDE_CBC_SHA; TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA; TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA; TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA; TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA; TLS_RSA_WITH_3DES_EDE_CBC_SHA; TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256; TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256; TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256; TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256; TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA; TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA; TLS_SRP_SHA_DSS_WITH_AES_128_CBC_SHA; TLS_SRP_SHA_RSA_WITH_AES_128_CBC_SHA; TLS_DHE_DSS_WITH_AES_128_GCM_SHA256; TLS_DHE_RSA_WITH_AES_128_GCM_SHA256; TLS_DHE_RSA_WITH_AES_128_CBC_SHA256; TLS_DHE_DSS_WITH_AES_128_CBC_SHA256; TLS_DHE_RSA_WITH_AES_128_CBC_SHA; TLS_DHE_DSS_WITH_AES_128_CBC_SHA; TLS_DHE_RSA_WITH_SEED_CBC_SHA; TLS_DHE_DSS_WITH_SEED_CBC_SHA; TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA; TLS_DHE_DSS_WITH_CAMELLIA_128_CBC_SHA; TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256; TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256; TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256; TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256; TLS_ECDH_RSA_WITH_AES_128_CBC_SHA; TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA; TLS_RSA_WITH_AES_128_GCM_SHA256; TLS_RSA_WITH_AES_128_CBC_SHA256; TLS_RSA_WITH_AES_128_CBC_SHA; TLS_RSA_WITH_SEED_CBC_SHA; TLS_RSA_WITH_CAMELLIA_128_CBC_SHA; TLS_RSA_WITH_IDEA_CBC_SHA; TLS_ECDHE_RSA_WITH_RC4_128_SHA; TLS_ECDHE_ECDSA_WITH_RC4_128_SHA; TLS_ECDH_RSA_WITH_RC4_128_SHA; TLS_ECDH_ECDSA_WITH_RC4_128_SHA; TLS_RSA_WITH_RC4_128_SHA; TLS_RSA_WITH_RC4_128_MD5; TLS_DHE_RSA_WITH_DES_CBC_SHA; TLS_DHE_DSS_WITH_DES_CBC_SHA; TLS_RSA_WITH_DES_CBC_SHA; TLS_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA; TLS_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA; TLS_RSA_EXPORT_WITH_DES40_CBC_SHA; TLS_RSA_EXPORT_WITH_RC2_CBC_40_MD5; TLS_RSA_EXPORT_WITH_RC4_40_MD5; TLS_EMPTY_RENEGOTIATION_INFO_SCSV]) ;
               extensions = [ECPointFormats Packet.([UNCOMPRESSED; ANSIX962_COMPRESSED_PRIME; ANSIX962_COMPRESSED_CHAR2]);
                             EllipticCurves Packet.([SECT571R1; SECT571K1; SECP521R1; SECT409K1; SECT409R1; SECP384R1; SECT283K1; SECT283R1; SECP256K1; SECP256R1; SECT239K1; SECT233K1; SECT233R1; SECP224K1; SECP224R1; SECT193R1; SECT193R2; SECP192K1; SECP192R1; SECT163K1; SECT163R1; SECT163R2; SECP160K1; SECP160R1; SECP160R2]);
@@ -1326,8 +1326,8 @@ let good_client_hellos =
               0x00; 0x00; 0x00; 0x0e; 0x00; 0x0c; 0x00; 0x00; 0x09; 0x31; 0x32; 0x37; 0x2e; 0x30; 0x2e; 0x30; 0x2e; 0x31; (* SNI 127.0.0.1 *)
               0x00; 0x0d; 0x00; 0x0c; 0x00; 0x0a; 0x06; 0x01; 0x05; 0x01; 0x04; 0x01; 0x02; 0x01; 0x01; 0x01 (* SignatureAlgorithms *)
             ],
-            { ch with version = TLS_1_X 4 ;
-                      random = list_to_cstruct [ 0xf1; 0xb2; 0x50; 0x16; 0x4b; 0x77; 0x50; 0xb3; 0xdc; 0xcb; 0x1c; 0x6a; 0xae; 0x1a; 0x94; 0x87; 0xc4; 0x17; 0xbb; 0xa4; 0xf7; 0x92; 0xf8; 0x16; 0x56; 0x12; 0x03; 0x38; 0x1e; 0xe5; 0xc1; 0xae ] ;
+            { ch with client_version = TLS_1_X 4 ;
+                      client_random = list_to_cstruct [ 0xf1; 0xb2; 0x50; 0x16; 0x4b; 0x77; 0x50; 0xb3; 0xdc; 0xcb; 0x1c; 0x6a; 0xae; 0x1a; 0x94; 0x87; 0xc4; 0x17; 0xbb; 0xa4; 0xf7; 0x92; 0xf8; 0x16; 0x56; 0x12; 0x03; 0x38; 0x1e; 0xe5; 0xc1; 0xae ] ;
                       ciphersuites = Packet.([TLS_RSA_WITH_AES_256_CBC_SHA ; TLS_DHE_RSA_WITH_AES_256_CBC_SHA ; TLS_RSA_WITH_AES_128_CBC_SHA ; TLS_DHE_RSA_WITH_AES_128_CBC_SHA ; TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA ; TLS_RSA_WITH_3DES_EDE_CBC_SHA ; TLS_RSA_WITH_RC4_128_SHA ; TLS_RSA_WITH_RC4_128_MD5]) ;
                       extensions = [ SecureRenegotiation (Cstruct.create 0) ;
                                      Hostname (Some "127.0.0.1") ;
@@ -1343,8 +1343,8 @@ let good_client_hellos =
 
 let cmp_client_hellos ch ch' =
   let open Core in
-  assert_equal ch.version ch'.version ;
-  assert_cs_eq ch.random ch'.random ;
+  assert_equal ch.client_version ch'.client_version ;
+  assert_cs_eq ch.client_random ch'.client_random ;
   assert_sessionid_equal ch.sessionid ch'.sessionid ;
   assert_lists_eq assert_equal ch.ciphersuites ch'.ciphersuites ;
   assert_lists_eq assert_extension_equal ch.extensions ch'.extensions
@@ -1447,25 +1447,25 @@ let good_server_hellos =
   (* I rolled the dice 16 times *)
   let rnd = [ 0; 1; 2; 3; 4; 5; 6; 7; 8; 9; 10; 11; 12; 13; 14; 15 ] in
   let rand = rnd @ rnd in
-  let random = list_to_cstruct rand in
+  let server_random = list_to_cstruct rand in
   Core.(let sh : server_hello =
-          { version = TLS_1_2 ;
-            random ;
+          { server_version = TLS_1_2 ;
+            server_random ;
             sessionid = None ;
-            ciphersuites = `TLS_RSA_WITH_RC4_128_MD5 ;
+            ciphersuite = `TLS_RSA_WITH_RC4_128_MD5 ;
             extensions = []}
         in
         [
           (* versions *)
           ([2; 0; 0; 38; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 4; (* comp *) 0; (* exts *)] , sh ) ;
-          ([2; 0; 0; 38; 3; 1] @ rand @ [(* session id *) 0; (* cipher *) 0; 4; (* comp *) 0; (* exts *)] , { sh with version = TLS_1_0 } ) ;
-          ([2; 0; 0; 38; 3; 2] @ rand @ [(* session id *) 0; (* cipher *) 0; 4; (* comp *) 0; (* exts *)] , { sh with version = TLS_1_1 } ) ;
+          ([2; 0; 0; 38; 3; 1] @ rand @ [(* session id *) 0; (* cipher *) 0; 4; (* comp *) 0; (* exts *)] , { sh with server_version = TLS_1_0 } ) ;
+          ([2; 0; 0; 38; 3; 2] @ rand @ [(* session id *) 0; (* cipher *) 0; 4; (* comp *) 0; (* exts *)] , { sh with server_version = TLS_1_1 } ) ;
 
           (* session id *)
           ([2; 0; 0; 41; 3; 3] @ rand @ [(* session id *) 3; 1; 2; 3; (* cipher *) 0; 4; (* comp *) 0; (* exts *)] , { sh with sessionid = Some (list_to_cstruct [1; 2; 3]) } ) ;
 
           (* ciphersuite *)
-          ([2; 0; 0; 38; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 5; (* comp *) 0; (* exts *)] , { sh with ciphersuites = `TLS_RSA_WITH_RC4_128_SHA } ) ;
+          ([2; 0; 0; 38; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 5; (* comp *) 0; (* exts *)] , { sh with ciphersuite = `TLS_RSA_WITH_RC4_128_SHA } ) ;
 
           (* extensions *)
           (* empty *)
@@ -1498,8 +1498,8 @@ let good_server_hellos =
             0x00; 0x00; 0x00; 0x00; (* servername *)
             0xff; 0x01; 0x00; 0x01; 0x00 (* secure renegotiation *)
           ], { sh with
-               ciphersuites = `TLS_RSA_WITH_AES_128_CBC_SHA ;
-               random = list_to_cstruct [ 0x53; 0x66; 0x2d; 0xf0; 0x1b; 0x61; 0x55; 0x8f; 0x74; 0x2a; 0xbf; 0xf4; 0x99; 0x86; 0x30; 0x99; 0x32; 0xe4; 0xd0; 0x1e; 0x2b; 0xa9; 0x2e; 0x86; 0x7b; 0xeb; 0x03; 0x00; 0xf9; 0x11; 0x3e; 0xc5 ] ;
+               ciphersuite = `TLS_RSA_WITH_AES_128_CBC_SHA ;
+               server_random = list_to_cstruct [ 0x53; 0x66; 0x2d; 0xf0; 0x1b; 0x61; 0x55; 0x8f; 0x74; 0x2a; 0xbf; 0xf4; 0x99; 0x86; 0x30; 0x99; 0x32; 0xe4; 0xd0; 0x1e; 0x2b; 0xa9; 0x2e; 0x86; 0x7b; 0xeb; 0x03; 0x00; 0xf9; 0x11; 0x3e; 0xc5 ] ;
                sessionid = Some (list_to_cstruct [ 0xd1; 0x54; 0xd9; 0x05; 0x61; 0x41; 0x53; 0x33; 0xb2; 0xf0; 0x13; 0x78; 0x1a; 0x17; 0xb3; 0x1d; 0x09; 0xf6; 0x59; 0x70; 0xfe; 0x5d; 0x58; 0x22; 0xfa; 0x8c; 0x5c; 0x89; 0xe9; 0xa2; 0xb4; 0x70 ]) ;
                extensions = [Hostname None;
                              SecureRenegotiation (Cstruct.create 0)] }) ;
@@ -1517,8 +1517,8 @@ let good_server_hellos =
             0x00; 0x00; 0x00; 0x00;
             0xff; 0x01; 0x00; 0x01; 0x00 ],
             { sh with
-              ciphersuites = `TLS_RSA_WITH_AES_128_CBC_SHA ;
-              random = list_to_cstruct [ 0x53; 0x66; 0x2f; 0xb7; 0x35; 0x3a; 0x42; 0xee; 0x1c; 0xe6; 0xed; 0x63; 0x8a; 0x1d; 0x3d; 0xb3; 0x71; 0x9c; 0xf5; 0x64; 0x45; 0xc5; 0xe9; 0xf4; 0x11; 0x8b; 0x9f; 0x41; 0x5a; 0x5f; 0xf1; 0xf6 ] ;
+              ciphersuite = `TLS_RSA_WITH_AES_128_CBC_SHA ;
+              server_random = list_to_cstruct [ 0x53; 0x66; 0x2f; 0xb7; 0x35; 0x3a; 0x42; 0xee; 0x1c; 0xe6; 0xed; 0x63; 0x8a; 0x1d; 0x3d; 0xb3; 0x71; 0x9c; 0xf5; 0x64; 0x45; 0xc5; 0xe9; 0xf4; 0x11; 0x8b; 0x9f; 0x41; 0x5a; 0x5f; 0xf1; 0xf6 ] ;
               sessionid = Some (list_to_cstruct [ 0xdf; 0xe1; 0x09; 0x8a; 0x42; 0xf0; 0x25; 0xc7; 0xbd; 0xe5; 0xe9; 0x02; 0x6a; 0x03; 0xaf; 0xb4; 0x70; 0x80; 0xe9; 0x2f; 0x07; 0x3f; 0x53; 0xd3; 0xc8; 0x97; 0x3f; 0xc4; 0x44; 0x23; 0xf5; 0x94 ] ) ;
               extensions = [Hostname None;
                             SecureRenegotiation (Cstruct.create 0)] }) ;
@@ -1527,10 +1527,10 @@ let good_server_hellos =
 
 let cmp_server_hellos sh sh' =
   let open Core in
-  assert_equal sh.version sh'.version ;
-  assert_cs_eq sh.random sh'.random ;
+  assert_equal sh.server_version sh'.server_version ;
+  assert_cs_eq sh.server_random sh'.server_random ;
   assert_sessionid_equal sh.sessionid sh'.sessionid ;
-  assert_equal sh.ciphersuites sh'.ciphersuites ;
+  assert_equal sh.ciphersuite sh'.ciphersuite ;
   assert_lists_eq assert_extension_equal sh.extensions sh'.extensions
 
 let good_server_hellos_parser (xs, res) _ =

--- a/tests/readertests.ml
+++ b/tests/readertests.ml
@@ -1191,48 +1191,44 @@ let good_client_hellos =
           (* empty *)
           ([1; 0; 0; 40; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 0] , ch ) ;
 
-          (* empty hostname *)
-          ([1; 0; 0; 44; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 4; 0; 0; 0; 0] , { ch with extensions = [Hostname None] } ) ;
           (* some hostname *)
-          ([1; 0; 0; 52; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 12; 0; 0; 0; 8; 0; 6; 0; 0; 3; 102; 111; 111] , { ch with extensions = [Hostname (Some "foo")] } ) ;
+          ([1; 0; 0; 52; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 12; 0; 0; 0; 8; 0; 6; 0; 0; 3; 102; 111; 111] , { ch with extensions = [`Hostname "foo"] } ) ;
           (* some other hostname *)
-          ([1; 0; 0; 59; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 19; 0; 0; 0; 15; 0; 13; 0; 0; 10; 102; 111; 111; 98; 97; 114; 46; 99; 111; 109] , { ch with extensions = [Hostname (Some "foobar.com")] } ) ;
-          (* hostname with unknown type! *)
-          ([1; 0; 0; 52; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 12; 0; 0; 0; 8; 0; 6; 2; 0; 3; 102; 111; 111] , { ch with extensions = [Hostname None] } ) ;
+          ([1; 0; 0; 59; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 19; 0; 0; 0; 15; 0; 13; 0; 0; 10; 102; 111; 111; 98; 97; 114; 46; 99; 111; 109] , { ch with extensions = [`Hostname "foobar.com"] } ) ;
 
           (* max fragment length *)
-          ([1; 0; 0; 45; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 5; 0; 1; 0; 1; 3] , { ch with extensions = [MaxFragmentLength Packet.TWO_11] } ) ;
+          ([1; 0; 0; 45; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 5; 0; 1; 0; 1; 3] , { ch with extensions = [`MaxFragmentLength Packet.TWO_11] } ) ;
 
           (* empty EllipticCurves *)
-          ([1; 0; 0; 46; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 6; 0; 0xA; 0; 2; 0; 0] , { ch with extensions = [EllipticCurves []] } ) ;
+          ([1; 0; 0; 46; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 6; 0; 0xA; 0; 2; 0; 0] , { ch with extensions = [`EllipticCurves []] } ) ;
           (* one elliptic curve *)
-          ([1; 0; 0; 48; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 8; 0; 0xA; 0; 4; 0; 2; 0; 25] , { ch with extensions = [EllipticCurves [Packet.SECP521R1]] } ) ;
+          ([1; 0; 0; 48; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 8; 0; 0xA; 0; 4; 0; 2; 0; 25] , { ch with extensions = [`EllipticCurves [Packet.SECP521R1]] } ) ;
           (* two elliptic curves *)
-          ([1; 0; 0; 50; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 10; 0; 0xA; 0; 6; 0; 4; 0; 25; 0; 20] , { ch with extensions = [EllipticCurves Packet.([SECP521R1; SECP224K1])] } ) ;
+          ([1; 0; 0; 50; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 10; 0; 0xA; 0; 6; 0; 4; 0; 25; 0; 20] , { ch with extensions = [`EllipticCurves Packet.([SECP521R1; SECP224K1])] } ) ;
           (* three elliptic curves, one unknown *)
-          ([1; 0; 0; 52; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 12; 0; 0xA; 0; 8; 0; 6; 0; 25; 0xFF; 0xFF; 0; 20] , { ch with extensions = [EllipticCurves Packet.([SECP521R1; SECP224K1])] } ) ;
+          ([1; 0; 0; 52; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 12; 0; 0xA; 0; 8; 0; 6; 0; 25; 0xFF; 0xFF; 0; 20] , { ch with extensions = [`EllipticCurves Packet.([SECP521R1; SECP224K1])] } ) ;
 
           (* empty ECPointFormats *)
-          ([1; 0; 0; 45; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 5; 0; 0xB; 0; 1; 0] , { ch with extensions = [ECPointFormats []] } ) ;
+          ([1; 0; 0; 45; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 5; 0; 0xB; 0; 1; 0] , { ch with extensions = [`ECPointFormats []] } ) ;
           (* one ECPointFormats *)
-          ([1; 0; 0; 46; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 6; 0; 0xB; 0; 2; 1; 0] , { ch with extensions = [ECPointFormats [Packet.UNCOMPRESSED]] } ) ;
+          ([1; 0; 0; 46; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 6; 0; 0xB; 0; 2; 1; 0] , { ch with extensions = [`ECPointFormats [Packet.UNCOMPRESSED]] } ) ;
           (* two ECPointFormats *)
-          ([1; 0; 0; 47; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 7; 0; 0xB; 0; 3; 2; 0; 1] , { ch with extensions = [ECPointFormats Packet.([UNCOMPRESSED ; ANSIX962_COMPRESSED_PRIME])] } ) ;
+          ([1; 0; 0; 47; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 7; 0; 0xB; 0; 3; 2; 0; 1] , { ch with extensions = [`ECPointFormats Packet.([UNCOMPRESSED ; ANSIX962_COMPRESSED_PRIME])] } ) ;
           (* three ECPointFormats, of which one is unknown *)
-          ([1; 0; 0; 48; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 8; 0; 0xB; 0; 4; 3; 0; 1; 23] , { ch with extensions = [ECPointFormats Packet.([UNCOMPRESSED ; ANSIX962_COMPRESSED_PRIME])] } ) ;
+          ([1; 0; 0; 48; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 8; 0; 0xB; 0; 4; 3; 0; 1; 23] , { ch with extensions = [`ECPointFormats Packet.([UNCOMPRESSED ; ANSIX962_COMPRESSED_PRIME])] } ) ;
 
           (* secure renegotiation *)
-          ([1; 0; 0; 47; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 7; 0xFF; 1; 0; 3; 2; 1; 2] , { ch with extensions = [SecureRenegotiation (list_to_cstruct [1;2])] } ) ;
+          ([1; 0; 0; 47; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 7; 0xFF; 1; 0; 3; 2; 1; 2] , { ch with extensions = [`SecureRenegotiation (list_to_cstruct [1;2])] } ) ;
 
           (* Padding *)
-          ([1; 0; 0; 47; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 7; 0; 21; 0; 3; 0; 0; 0] , { ch with extensions = [Padding 3] } ) ;
+          ([1; 0; 0; 47; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 7; 0; 21; 0; 3; 0; 0; 0] , { ch with extensions = [`Padding 3] } ) ;
 
           (* signature algorithm *)
-          ([1; 0; 0; 46; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 6; 0; 13; 0; 2; 0; 0] , { ch with extensions = [SignatureAlgorithms []] } ) ;
-          ([1; 0; 0; 48; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 8; 0; 13; 0; 4; 0; 2; 1; 0] , { ch with extensions = [SignatureAlgorithms [(`MD5, Packet.ANONYMOUS)]] } ) ;
-          ([1; 0; 0; 50; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 10; 0; 13; 0; 6; 0; 4; 2; 0; 1; 1] , { ch with extensions = [SignatureAlgorithms [(`SHA1, Packet.ANONYMOUS); (`MD5, Packet.RSA)]] } ) ;
+          ([1; 0; 0; 46; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 6; 0; 13; 0; 2; 0; 0] , { ch with extensions = [`SignatureAlgorithms []] } ) ;
+          ([1; 0; 0; 48; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 8; 0; 13; 0; 4; 0; 2; 1; 0] , { ch with extensions = [`SignatureAlgorithms [(`MD5, Packet.ANONYMOUS)]] } ) ;
+          ([1; 0; 0; 50; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 10; 0; 13; 0; 6; 0; 4; 2; 0; 1; 1] , { ch with extensions = [`SignatureAlgorithms [(`SHA1, Packet.ANONYMOUS); (`MD5, Packet.RSA)]] } ) ;
           (* unknown one *)
-          ([1; 0; 0; 52; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 12; 0; 13; 0; 8; 0; 6; 42; 42; 1; 0; 1; 1] , { ch with extensions = [SignatureAlgorithms [(`MD5, Packet.ANONYMOUS); (`MD5, Packet.RSA)]] } ) ;
+          ([1; 0; 0; 52; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 0; (* comp *) 0; (* exts *) 0; 12; 0; 13; 0; 8; 0; 6; 42; 42; 1; 0; 1; 1] , { ch with extensions = [`SignatureAlgorithms [(`MD5, Packet.ANONYMOUS); (`MD5, Packet.RSA)]] } ) ;
 
           (* combinations from the real world *)
           ([0x01; (* hello *)
@@ -1253,8 +1249,8 @@ let good_client_hellos =
              client_version = Supported TLS_1_0 ;
              client_random =  list_to_cstruct [0x7c; 0x53; 0x05; 0x72; 0x7a; 0x1b; 0x84; 0x70; 0x30; 0x89; 0xef; 0xad; 0xfb; 0x56; 0xc1; 0x3d; 0x73; 0x4b; 0xc7; 0xcb; 0x8c; 0xc8; 0x75; 0x43; 0x01; 0x12; 0x32; 0xd6; 0x74; 0x87; 0xcb; 0x18] ;
              ciphersuites = Packet.([TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA; TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA; TLS_SRP_SHA_DSS_WITH_AES_256_CBC_SHA; TLS_SRP_SHA_RSA_WITH_AES_256_CBC_SHA; TLS_DHE_RSA_WITH_AES_256_CBC_SHA; TLS_DHE_DSS_WITH_AES_256_CBC_SHA; TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA; TLS_DHE_DSS_WITH_CAMELLIA_256_CBC_SHA; TLS_ECDH_RSA_WITH_AES_256_CBC_SHA; TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA; TLS_RSA_WITH_AES_256_CBC_SHA; TLS_RSA_WITH_CAMELLIA_256_CBC_SHA; TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA; TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA; TLS_SRP_SHA_DSS_WITH_3DES_EDE_CBC_SHA; TLS_SRP_SHA_RSA_WITH_3DES_EDE_CBC_SHA; TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA; TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA; TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA; TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA; TLS_RSA_WITH_3DES_EDE_CBC_SHA; TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA; TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA; TLS_SRP_SHA_DSS_WITH_AES_128_CBC_SHA; TLS_SRP_SHA_RSA_WITH_AES_128_CBC_SHA; TLS_DHE_RSA_WITH_AES_128_CBC_SHA; TLS_DHE_DSS_WITH_AES_128_CBC_SHA; TLS_DHE_RSA_WITH_SEED_CBC_SHA; TLS_DHE_DSS_WITH_SEED_CBC_SHA; TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA; TLS_DHE_DSS_WITH_CAMELLIA_128_CBC_SHA; TLS_ECDH_RSA_WITH_AES_128_CBC_SHA; TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA; TLS_RSA_WITH_AES_128_CBC_SHA; TLS_RSA_WITH_SEED_CBC_SHA; TLS_RSA_WITH_CAMELLIA_128_CBC_SHA; TLS_RSA_WITH_IDEA_CBC_SHA; TLS_ECDHE_RSA_WITH_RC4_128_SHA; TLS_ECDHE_ECDSA_WITH_RC4_128_SHA; TLS_ECDH_RSA_WITH_RC4_128_SHA; TLS_ECDH_ECDSA_WITH_RC4_128_SHA; TLS_RSA_WITH_RC4_128_SHA; TLS_RSA_WITH_RC4_128_MD5; TLS_DHE_RSA_WITH_DES_CBC_SHA; TLS_DHE_DSS_WITH_DES_CBC_SHA; TLS_RSA_WITH_DES_CBC_SHA; TLS_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA; TLS_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA; TLS_RSA_EXPORT_WITH_DES40_CBC_SHA; TLS_RSA_EXPORT_WITH_RC2_CBC_40_MD5; TLS_RSA_EXPORT_WITH_RC4_40_MD5; TLS_EMPTY_RENEGOTIATION_INFO_SCSV]);
-             extensions = [ECPointFormats Packet.([UNCOMPRESSED; ANSIX962_COMPRESSED_PRIME; ANSIX962_COMPRESSED_CHAR2]) ;
-                           EllipticCurves Packet.([SECT571R1; SECT571K1; SECP521R1; SECT409K1; SECT409R1; SECP384R1; SECT283K1; SECT283R1; SECP256K1; SECP256R1; SECT239K1; SECT233K1; SECT233R1; SECP224K1; SECP224R1; SECT193R1; SECT193R2; SECP192K1; SECP192R1; SECT163K1; SECT163R1; SECT163R2; SECP160K1; SECP160R1; SECP160R2]) ] } ) ;
+             extensions = [`ECPointFormats Packet.([UNCOMPRESSED; ANSIX962_COMPRESSED_PRIME; ANSIX962_COMPRESSED_CHAR2]) ;
+                           `EllipticCurves Packet.([SECT571R1; SECT571K1; SECP521R1; SECT409K1; SECT409R1; SECP384R1; SECT283K1; SECT283R1; SECP256K1; SECP256R1; SECT239K1; SECT233K1; SECT233R1; SECP224K1; SECP224R1; SECT193R1; SECT193R2; SECP192K1; SECP192R1; SECT163K1; SECT163R1; SECT163R2; SECP160K1; SECP160R1; SECP160R2]) ] } ) ;
 
           (
             [ 0x01; (* client hello *)
@@ -1292,9 +1288,9 @@ let good_client_hellos =
               client_version = Supported TLS_1_2 ;
               client_random = list_to_cstruct [0xb7; 0x36; 0xeb; 0x21; 0xec; 0x81; 0x4d; 0x01; 0xfc; 0xf4; 0xe2; 0x06; 0x9a; 0x34; 0xb7; 0x21; 0xe1; 0x23; 0x6f; 0xbe; 0x50; 0xbf; 0xfe; 0x33; 0x9b; 0xc9; 0x5b; 0x20; 0x0e; 0x15; 0x02; 0x27] ;
               ciphersuites = Packet.([TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384; TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384; TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384; TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384; TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA; TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA; TLS_SRP_SHA_DSS_WITH_AES_256_CBC_SHA; TLS_SRP_SHA_RSA_WITH_AES_256_CBC_SHA; TLS_DHE_DSS_WITH_AES_256_GCM_SHA384; TLS_DHE_RSA_WITH_AES_256_GCM_SHA384; TLS_DHE_RSA_WITH_AES_256_CBC_SHA256; TLS_DHE_DSS_WITH_AES_256_CBC_SHA256; TLS_DHE_RSA_WITH_AES_256_CBC_SHA; TLS_DHE_DSS_WITH_AES_256_CBC_SHA; TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA; TLS_DHE_DSS_WITH_CAMELLIA_256_CBC_SHA; TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384; TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384; TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384; TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384; TLS_ECDH_RSA_WITH_AES_256_CBC_SHA; TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA; TLS_RSA_WITH_AES_256_GCM_SHA384; TLS_RSA_WITH_AES_256_CBC_SHA256; TLS_RSA_WITH_AES_256_CBC_SHA; TLS_RSA_WITH_CAMELLIA_256_CBC_SHA; TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA; TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA; TLS_SRP_SHA_DSS_WITH_3DES_EDE_CBC_SHA; TLS_SRP_SHA_RSA_WITH_3DES_EDE_CBC_SHA; TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA; TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA; TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA; TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA; TLS_RSA_WITH_3DES_EDE_CBC_SHA; TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256; TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256; TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256; TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256; TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA; TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA; TLS_SRP_SHA_DSS_WITH_AES_128_CBC_SHA; TLS_SRP_SHA_RSA_WITH_AES_128_CBC_SHA; TLS_DHE_DSS_WITH_AES_128_GCM_SHA256; TLS_DHE_RSA_WITH_AES_128_GCM_SHA256; TLS_DHE_RSA_WITH_AES_128_CBC_SHA256; TLS_DHE_DSS_WITH_AES_128_CBC_SHA256; TLS_DHE_RSA_WITH_AES_128_CBC_SHA; TLS_DHE_DSS_WITH_AES_128_CBC_SHA; TLS_DHE_RSA_WITH_SEED_CBC_SHA; TLS_DHE_DSS_WITH_SEED_CBC_SHA; TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA; TLS_DHE_DSS_WITH_CAMELLIA_128_CBC_SHA; TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256; TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256; TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256; TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256; TLS_ECDH_RSA_WITH_AES_128_CBC_SHA; TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA; TLS_RSA_WITH_AES_128_GCM_SHA256; TLS_RSA_WITH_AES_128_CBC_SHA256; TLS_RSA_WITH_AES_128_CBC_SHA; TLS_RSA_WITH_SEED_CBC_SHA; TLS_RSA_WITH_CAMELLIA_128_CBC_SHA; TLS_RSA_WITH_IDEA_CBC_SHA; TLS_ECDHE_RSA_WITH_RC4_128_SHA; TLS_ECDHE_ECDSA_WITH_RC4_128_SHA; TLS_ECDH_RSA_WITH_RC4_128_SHA; TLS_ECDH_ECDSA_WITH_RC4_128_SHA; TLS_RSA_WITH_RC4_128_SHA; TLS_RSA_WITH_RC4_128_MD5; TLS_DHE_RSA_WITH_DES_CBC_SHA; TLS_DHE_DSS_WITH_DES_CBC_SHA; TLS_RSA_WITH_DES_CBC_SHA; TLS_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA; TLS_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA; TLS_RSA_EXPORT_WITH_DES40_CBC_SHA; TLS_RSA_EXPORT_WITH_RC2_CBC_40_MD5; TLS_RSA_EXPORT_WITH_RC4_40_MD5; TLS_EMPTY_RENEGOTIATION_INFO_SCSV]) ;
-              extensions = [ECPointFormats Packet.([UNCOMPRESSED; ANSIX962_COMPRESSED_PRIME; ANSIX962_COMPRESSED_CHAR2]);
-                            EllipticCurves Packet.([SECT571R1; SECT571K1; SECP521R1; SECT409K1; SECT409R1; SECP384R1; SECT283K1; SECT283R1; SECP256K1; SECP256R1; SECT239K1; SECT233K1; SECT233R1; SECP224K1; SECP224R1; SECT193R1; SECT193R2; SECP192K1; SECP192R1; SECT163K1; SECT163R1; SECT163R2; SECP160K1; SECP160R1; SECP160R2]);
-                            SignatureAlgorithms
+              extensions = [`ECPointFormats Packet.([UNCOMPRESSED; ANSIX962_COMPRESSED_PRIME; ANSIX962_COMPRESSED_CHAR2]);
+                            `EllipticCurves Packet.([SECT571R1; SECT571K1; SECP521R1; SECT409K1; SECT409R1; SECP384R1; SECT283K1; SECT283R1; SECP256K1; SECP256R1; SECT239K1; SECT233K1; SECT233R1; SECP224K1; SECP224R1; SECT193R1; SECT193R2; SECP192K1; SECP192R1; SECT163K1; SECT163R1; SECT163R2; SECP160K1; SECP160R1; SECP160R2]);
+                            `SignatureAlgorithms
                               [(`SHA512, Packet.RSA) ;
                                (`SHA512, Packet.DSA) ;
                                (`SHA512, Packet.ECDSA) ;
@@ -1310,7 +1306,7 @@ let good_client_hellos =
                                (`SHA1, Packet.RSA) ;
                                (`SHA1, Packet.DSA) ;
                                (`SHA1, Packet.ECDSA)] ;
-                            Padding 203] } );
+                            `Padding 203] } );
 
 
           ( [ 0x01; (* client hello *)
@@ -1329,9 +1325,9 @@ let good_client_hellos =
             { ch with client_version = TLS_1_X 4 ;
                       client_random = list_to_cstruct [ 0xf1; 0xb2; 0x50; 0x16; 0x4b; 0x77; 0x50; 0xb3; 0xdc; 0xcb; 0x1c; 0x6a; 0xae; 0x1a; 0x94; 0x87; 0xc4; 0x17; 0xbb; 0xa4; 0xf7; 0x92; 0xf8; 0x16; 0x56; 0x12; 0x03; 0x38; 0x1e; 0xe5; 0xc1; 0xae ] ;
                       ciphersuites = Packet.([TLS_RSA_WITH_AES_256_CBC_SHA ; TLS_DHE_RSA_WITH_AES_256_CBC_SHA ; TLS_RSA_WITH_AES_128_CBC_SHA ; TLS_DHE_RSA_WITH_AES_128_CBC_SHA ; TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA ; TLS_RSA_WITH_3DES_EDE_CBC_SHA ; TLS_RSA_WITH_RC4_128_SHA ; TLS_RSA_WITH_RC4_128_MD5]) ;
-                      extensions = [ SecureRenegotiation (Cstruct.create 0) ;
-                                     Hostname (Some "127.0.0.1") ;
-                                     SignatureAlgorithms
+                      extensions = [ `SecureRenegotiation (Cstruct.create 0) ;
+                                     `Hostname "127.0.0.1" ;
+                                     `SignatureAlgorithms
                                        [(`SHA512, Packet.RSA) ;
                                         (`SHA384, Packet.RSA) ;
                                         (`SHA256, Packet.RSA) ;
@@ -1347,7 +1343,7 @@ let cmp_client_hellos ch ch' =
   assert_cs_eq ch.client_random ch'.client_random ;
   assert_sessionid_equal ch.sessionid ch'.sessionid ;
   assert_lists_eq assert_equal ch.ciphersuites ch'.ciphersuites ;
-  assert_lists_eq assert_extension_equal ch.extensions ch'.extensions
+  assert_lists_eq assert_client_extension_equal ch.extensions ch'.extensions
 
 let good_client_hellos_parser (xs, res) _ =
   let buf = list_to_cstruct xs in
@@ -1472,7 +1468,7 @@ let good_server_hellos =
           ([2; 0; 0; 40; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 4; (* comp *) 0; (* exts *) 0; 0] , sh ) ;
 
           (* empty hostname *)
-          ([2; 0; 0; 44; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 4; (* comp *) 0; (* exts *) 0; 4; 0; 0; 0; 0] , { sh with extensions = [Hostname None] } ) ;
+          ([2; 0; 0; 44; 3; 3] @ rand @ [(* session id *) 0; (* cipher *) 0; 4; (* comp *) 0; (* exts *) 0; 4; 0; 0; 0; 0] , { sh with extensions = [`Hostname] } ) ;
 
           (* TODO: chosen ciphersuite must not be renegotiation (0x00ff) *)
 
@@ -1501,8 +1497,8 @@ let good_server_hellos =
                ciphersuite = `TLS_RSA_WITH_AES_128_CBC_SHA ;
                server_random = list_to_cstruct [ 0x53; 0x66; 0x2d; 0xf0; 0x1b; 0x61; 0x55; 0x8f; 0x74; 0x2a; 0xbf; 0xf4; 0x99; 0x86; 0x30; 0x99; 0x32; 0xe4; 0xd0; 0x1e; 0x2b; 0xa9; 0x2e; 0x86; 0x7b; 0xeb; 0x03; 0x00; 0xf9; 0x11; 0x3e; 0xc5 ] ;
                sessionid = Some (list_to_cstruct [ 0xd1; 0x54; 0xd9; 0x05; 0x61; 0x41; 0x53; 0x33; 0xb2; 0xf0; 0x13; 0x78; 0x1a; 0x17; 0xb3; 0x1d; 0x09; 0xf6; 0x59; 0x70; 0xfe; 0x5d; 0x58; 0x22; 0xfa; 0x8c; 0x5c; 0x89; 0xe9; 0xa2; 0xb4; 0x70 ]) ;
-               extensions = [Hostname None;
-                             SecureRenegotiation (Cstruct.create 0)] }) ;
+               extensions = [`Hostname;
+                             `SecureRenegotiation (Cstruct.create 0)] }) ;
 
           ( [
             0x02;
@@ -1520,8 +1516,8 @@ let good_server_hellos =
               ciphersuite = `TLS_RSA_WITH_AES_128_CBC_SHA ;
               server_random = list_to_cstruct [ 0x53; 0x66; 0x2f; 0xb7; 0x35; 0x3a; 0x42; 0xee; 0x1c; 0xe6; 0xed; 0x63; 0x8a; 0x1d; 0x3d; 0xb3; 0x71; 0x9c; 0xf5; 0x64; 0x45; 0xc5; 0xe9; 0xf4; 0x11; 0x8b; 0x9f; 0x41; 0x5a; 0x5f; 0xf1; 0xf6 ] ;
               sessionid = Some (list_to_cstruct [ 0xdf; 0xe1; 0x09; 0x8a; 0x42; 0xf0; 0x25; 0xc7; 0xbd; 0xe5; 0xe9; 0x02; 0x6a; 0x03; 0xaf; 0xb4; 0x70; 0x80; 0xe9; 0x2f; 0x07; 0x3f; 0x53; 0xd3; 0xc8; 0x97; 0x3f; 0xc4; 0x44; 0x23; 0xf5; 0x94 ] ) ;
-              extensions = [Hostname None;
-                            SecureRenegotiation (Cstruct.create 0)] }) ;
+              extensions = [`Hostname;
+                            `SecureRenegotiation (Cstruct.create 0)] }) ;
 
        ])
 
@@ -1531,7 +1527,7 @@ let cmp_server_hellos sh sh' =
   assert_cs_eq sh.server_random sh'.server_random ;
   assert_sessionid_equal sh.sessionid sh'.sessionid ;
   assert_equal sh.ciphersuite sh'.ciphersuite ;
-  assert_lists_eq assert_extension_equal sh.extensions sh'.extensions
+  assert_lists_eq assert_server_extension_equal sh.extensions sh'.extensions
 
 let good_server_hellos_parser (xs, res) _ =
   let buf = list_to_cstruct xs in

--- a/tests/readerwritertests.ml
+++ b/tests/readerwritertests.ml
@@ -353,28 +353,28 @@ let rw_handshake_client_hello hs _ =
 
 let rw_handshake_client_hello_vals =
   let rnd = [ 0; 1; 2; 3; 4; 5; 6; 7; 8; 9; 10; 11; 12; 13; 14; 15 ] in
-  let random = list_to_cstruct (rnd @ rnd) in
+  let client_random = list_to_cstruct (rnd @ rnd) in
   Core.(let ch : client_hello =
-          { version = Supported TLS_1_2 ;
-            random ;
+          { client_version = Supported TLS_1_2 ;
+            client_random ;
             sessionid = None ;
             ciphersuites = [] ;
             extensions = []}
         in
         [
           ClientHello ch ;
-          ClientHello { ch with version = Supported TLS_1_0 } ;
-          ClientHello { ch with version = Supported TLS_1_1 } ;
+          ClientHello { ch with client_version = Supported TLS_1_0 } ;
+          ClientHello { ch with client_version = Supported TLS_1_1 } ;
 
           ClientHello { ch with ciphersuites = [ Packet.TLS_NULL_WITH_NULL_NULL ] } ;
           ClientHello { ch with ciphersuites = Packet.([ TLS_NULL_WITH_NULL_NULL ; TLS_RSA_WITH_NULL_MD5 ; TLS_RSA_WITH_AES_256_CBC_SHA ]) } ;
 
           ClientHello { ch with sessionid = (Some (list_to_cstruct rnd)) } ;
-          ClientHello { ch with sessionid = (Some random) } ;
+          ClientHello { ch with sessionid = (Some client_random) } ;
 
           ClientHello { ch with
                         ciphersuites = Packet.([ TLS_NULL_WITH_NULL_NULL ; TLS_RSA_WITH_NULL_MD5 ; TLS_RSA_WITH_AES_256_CBC_SHA ]) ;
-                        sessionid = (Some random) } ;
+                        sessionid = (Some client_random) } ;
 
           ClientHello { ch with extensions = [ Hostname None ] } ;
           ClientHello { ch with extensions = [ Hostname None ; Hostname None ] } ;
@@ -392,12 +392,12 @@ let rw_handshake_client_hello_vals =
 
           ClientHello { ch with
                         ciphersuites = Packet.([ TLS_NULL_WITH_NULL_NULL ; TLS_RSA_WITH_NULL_MD5 ; TLS_RSA_WITH_AES_256_CBC_SHA ]) ;
-                        sessionid = (Some random) ;
+                        sessionid = (Some client_random) ;
                         extensions = [ Hostname (Some "foobarblubb") ] } ;
 
           ClientHello { ch with
                         ciphersuites = Packet.([ TLS_NULL_WITH_NULL_NULL ; TLS_RSA_WITH_NULL_MD5 ; TLS_RSA_WITH_AES_256_CBC_SHA ]) ;
-                        sessionid = (Some random) ;
+                        sessionid = (Some client_random) ;
                         extensions = [
                              Hostname (Some "foobarblubb") ;
                              EllipticCurves Packet.([SECP521R1; SECP384R1]) ;
@@ -407,13 +407,13 @@ let rw_handshake_client_hello_vals =
 
           ClientHello { ch with
                         ciphersuites = Packet.([ TLS_NULL_WITH_NULL_NULL ; TLS_RSA_WITH_NULL_MD5 ; TLS_RSA_WITH_AES_256_CBC_SHA ]) ;
-                        sessionid = (Some random) ;
+                        sessionid = (Some client_random) ;
                         extensions = [
                              Hostname (Some "foobarblubb") ;
                              EllipticCurves Packet.([SECP521R1; SECP384R1]) ;
                              ECPointFormats Packet.([UNCOMPRESSED ; ANSIX962_COMPRESSED_PRIME ;   ANSIX962_COMPRESSED_CHAR2 ]) ;
                              SignatureAlgorithms [(`MD5, Packet.ANONYMOUS); (`SHA1, Packet.RSA)] ;
-                             SecureRenegotiation random
+                             SecureRenegotiation client_random
                       ] } ;
 
         ])
@@ -444,29 +444,29 @@ let rw_handshake_server_hello hs _ =
 
 let rw_handshake_server_hello_vals =
   let rnd = [ 0; 1; 2; 3; 4; 5; 6; 7; 8; 9; 10; 11; 12; 13; 14; 15 ] in
-  let random = list_to_cstruct (rnd @ rnd) in
+  let server_random = list_to_cstruct (rnd @ rnd) in
   Core.(let sh : server_hello =
-          { version = TLS_1_2 ;
-            random ;
+          { server_version = TLS_1_2 ;
+            server_random ;
             sessionid = None ;
-            ciphersuites = `TLS_RSA_WITH_RC4_128_MD5 ;
+            ciphersuite = `TLS_RSA_WITH_RC4_128_MD5 ;
             extensions = []}
         in
         [
           ServerHello sh ;
-          ServerHello { sh with version = TLS_1_0 } ;
-          ServerHello { sh with version = TLS_1_1 } ;
+          ServerHello { sh with server_version = TLS_1_0 } ;
+          ServerHello { sh with server_version = TLS_1_1 } ;
 
-          ServerHello { sh with sessionid = (Some random) } ;
+          ServerHello { sh with sessionid = (Some server_random) } ;
 
           ServerHello { sh with
-                        sessionid = (Some random) ;
+                        sessionid = (Some server_random) ;
                         extensions = [Hostname None]
                       } ;
 
           ServerHello { sh with
-                        sessionid = (Some random) ;
-                        extensions = [Hostname None ; SecureRenegotiation random]
+                        sessionid = (Some server_random) ;
+                        extensions = [Hostname None ; SecureRenegotiation server_random]
                       } ;
 
         ])

--- a/tests/readerwritertests.ml
+++ b/tests/readerwritertests.ml
@@ -376,44 +376,42 @@ let rw_handshake_client_hello_vals =
                         ciphersuites = Packet.([ TLS_NULL_WITH_NULL_NULL ; TLS_RSA_WITH_NULL_MD5 ; TLS_RSA_WITH_AES_256_CBC_SHA ]) ;
                         sessionid = (Some client_random) } ;
 
-          ClientHello { ch with extensions = [ Hostname None ] } ;
-          ClientHello { ch with extensions = [ Hostname None ; Hostname None ] } ;
-          ClientHello { ch with extensions = [ Hostname (Some "foobar") ] } ;
-          ClientHello { ch with extensions = [ Hostname (Some "foobarblubb") ] } ;
+          ClientHello { ch with extensions = [ `Hostname "foobar" ] } ;
+          ClientHello { ch with extensions = [ `Hostname "foobarblubb" ] } ;
 
-          ClientHello { ch with extensions = [ Hostname (Some "foobarblubb") ; EllipticCurves Packet.([SECP521R1; SECP384R1]) ] } ;
+          ClientHello { ch with extensions = [ `Hostname "foobarblubb" ; `EllipticCurves Packet.([SECP521R1; SECP384R1]) ] } ;
 
           ClientHello { ch with extensions = [
-                             Hostname (Some "foobarblubb") ;
-                             EllipticCurves Packet.([SECP521R1; SECP384R1]) ;
-                             ECPointFormats Packet.([UNCOMPRESSED ; ANSIX962_COMPRESSED_PRIME ;   ANSIX962_COMPRESSED_CHAR2 ]) ;
-                             SignatureAlgorithms [(`MD5, Packet.RSA)]
+                             `Hostname "foobarblubb" ;
+                             `EllipticCurves Packet.([SECP521R1; SECP384R1]) ;
+                             `ECPointFormats Packet.([UNCOMPRESSED ; ANSIX962_COMPRESSED_PRIME ;   ANSIX962_COMPRESSED_CHAR2 ]) ;
+                             `SignatureAlgorithms [(`MD5, Packet.RSA)]
                            ] } ;
 
           ClientHello { ch with
                         ciphersuites = Packet.([ TLS_NULL_WITH_NULL_NULL ; TLS_RSA_WITH_NULL_MD5 ; TLS_RSA_WITH_AES_256_CBC_SHA ]) ;
                         sessionid = (Some client_random) ;
-                        extensions = [ Hostname (Some "foobarblubb") ] } ;
+                        extensions = [ `Hostname "foobarblubb" ] } ;
 
           ClientHello { ch with
                         ciphersuites = Packet.([ TLS_NULL_WITH_NULL_NULL ; TLS_RSA_WITH_NULL_MD5 ; TLS_RSA_WITH_AES_256_CBC_SHA ]) ;
                         sessionid = (Some client_random) ;
                         extensions = [
-                             Hostname (Some "foobarblubb") ;
-                             EllipticCurves Packet.([SECP521R1; SECP384R1]) ;
-                             ECPointFormats Packet.([UNCOMPRESSED ; ANSIX962_COMPRESSED_PRIME ;   ANSIX962_COMPRESSED_CHAR2 ]) ;
-                             SignatureAlgorithms [(`SHA1, Packet.ANONYMOUS); (`MD5, Packet.RSA)]
+                             `Hostname "foobarblubb" ;
+                             `EllipticCurves Packet.([SECP521R1; SECP384R1]) ;
+                             `ECPointFormats Packet.([UNCOMPRESSED ; ANSIX962_COMPRESSED_PRIME ;   ANSIX962_COMPRESSED_CHAR2 ]) ;
+                             `SignatureAlgorithms [(`SHA1, Packet.ANONYMOUS); (`MD5, Packet.RSA)]
                       ] } ;
 
           ClientHello { ch with
                         ciphersuites = Packet.([ TLS_NULL_WITH_NULL_NULL ; TLS_RSA_WITH_NULL_MD5 ; TLS_RSA_WITH_AES_256_CBC_SHA ]) ;
                         sessionid = (Some client_random) ;
                         extensions = [
-                             Hostname (Some "foobarblubb") ;
-                             EllipticCurves Packet.([SECP521R1; SECP384R1]) ;
-                             ECPointFormats Packet.([UNCOMPRESSED ; ANSIX962_COMPRESSED_PRIME ;   ANSIX962_COMPRESSED_CHAR2 ]) ;
-                             SignatureAlgorithms [(`MD5, Packet.ANONYMOUS); (`SHA1, Packet.RSA)] ;
-                             SecureRenegotiation client_random
+                             `Hostname "foobarblubb" ;
+                             `EllipticCurves Packet.([SECP521R1; SECP384R1]) ;
+                             `ECPointFormats Packet.([UNCOMPRESSED ; ANSIX962_COMPRESSED_PRIME ;   ANSIX962_COMPRESSED_CHAR2 ]) ;
+                             `SignatureAlgorithms [(`MD5, Packet.ANONYMOUS); (`SHA1, Packet.RSA)] ;
+                             `SecureRenegotiation client_random
                       ] } ;
 
         ])
@@ -461,12 +459,12 @@ let rw_handshake_server_hello_vals =
 
           ServerHello { sh with
                         sessionid = (Some server_random) ;
-                        extensions = [Hostname None]
+                        extensions = [`Hostname]
                       } ;
 
           ServerHello { sh with
                         sessionid = (Some server_random) ;
-                        extensions = [Hostname None ; SecureRenegotiation server_random]
+                        extensions = [`Hostname ; `SecureRenegotiation server_random]
                       } ;
 
         ])

--- a/tests/testlib.ml
+++ b/tests/testlib.ml
@@ -48,17 +48,24 @@ let assert_sessionid_equal a b =
   | Some x, Some y -> assert_cs_eq x y
   | _ -> assert_failure "session id not equal"
 
-let assert_extension_equal a b =
+let assert_client_extension_equal a b =
   Core.(match a, b with
-        | Hostname None, Hostname None -> ()
-        | Hostname (Some a), Hostname (Some b) -> assert_equal a b
-        | MaxFragmentLength a, MaxFragmentLength b -> assert_equal a b
-        | EllipticCurves a, EllipticCurves b -> assert_lists_eq assert_equal a b
-        | ECPointFormats a, ECPointFormats b -> assert_lists_eq assert_equal a b
-        | SecureRenegotiation a, SecureRenegotiation b -> assert_cs_eq a b
-        | Padding a, Padding b -> assert_equal a b
-        | SignatureAlgorithms a, SignatureAlgorithms b ->
+        | `Hostname a, `Hostname b -> assert_equal a b
+        | `MaxFragmentLength a, `MaxFragmentLength b -> assert_equal a b
+        | `EllipticCurves a, `EllipticCurves b -> assert_lists_eq assert_equal a b
+        | `ECPointFormats a, `ECPointFormats b -> assert_lists_eq assert_equal a b
+        | `SecureRenegotiation a, `SecureRenegotiation b -> assert_cs_eq a b
+        | `Padding a, `Padding b -> assert_equal a b
+        | `SignatureAlgorithms a, `SignatureAlgorithms b ->
            assert_lists_eq (fun (h, s) (h', s') -> assert_equal h h' ; assert_equal s s') a b
+        | _ -> assert_failure "extensions did not match")
+
+let assert_server_extension_equal a b =
+  Core.(match a, b with
+        | `Hostname, `Hostname -> ()
+        | `MaxFragmentLength a, `MaxFragmentLength b -> assert_equal a b
+        | `ECPointFormats a, `ECPointFormats b -> assert_lists_eq assert_equal a b
+        | `SecureRenegotiation a, `SecureRenegotiation b -> assert_cs_eq a b
         | _ -> assert_failure "extensions did not match")
 
 let cs_mmap file =

--- a/tests/writertests.ml
+++ b/tests/writertests.ml
@@ -314,7 +314,7 @@ let handshake_assembler_tests =
                    sessionid = None ;
                    ciphersuites = Packet.([TLS_NULL_WITH_NULL_NULL ; TLS_RSA_WITH_NULL_MD5 ; TLS_RSA_WITH_NULL_SHA ; TLS_RSA_EXPORT_WITH_RC4_40_MD5]);
                    extensions = [
-                            SignatureAlgorithms
+                            `SignatureAlgorithms
                               [(`SHA512, Packet.RSA) ;
                                (`SHA512, Packet.DSA) ;
                                (`SHA512, Packet.ECDSA) ;
@@ -340,21 +340,21 @@ let handshake_assembler_tests =
                    client_random = a_cs <+> a_cs ;
                    sessionid = None ;
                    ciphersuites = [Packet.TLS_NULL_WITH_NULL_NULL] ;
-                   extensions = [Hostname (Some "foo")] },
+                   extensions = [`Hostname "foo"] },
      [ 1; 0; 0; 55; 3; 3 ] @ a_l @ a_l @ [ 0; 0; 2; 0; 0; 1; 0; 0; 12; 0; 0; 0; 8; 0; 6; 0; 0; 3; 102; 111; 111 ] ) ;
 
    ( ClientHello { client_version = Supported TLS_1_2 ;
                    client_random = a_cs <+> a_cs ;
                    sessionid = None ;
                    ciphersuites = [Packet.TLS_NULL_WITH_NULL_NULL] ;
-                   extensions = [Hostname (Some "foofoofoofoofoofoofoofoofoofoo")] },
+                   extensions = [`Hostname "foofoofoofoofoofoofoofoofoofoo"] },
      [ 1; 0; 0; 82; 3; 3 ] @ a_l @ a_l @ [ 0; 0; 2; 0; 0; 1; 0; 0; 39; 0; 0; 0; 35; 0; 33; 0; 0; 30; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111 ] ) ;
 
    ( ClientHello { client_version = Supported TLS_1_2 ;
                    client_random = a_cs <+> a_cs ;
                    sessionid = None ;
                    ciphersuites = [Packet.TLS_NULL_WITH_NULL_NULL] ;
-                   extensions = [Hostname (Some "foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo")] },
+                   extensions = [`Hostname "foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo"] },
      [ 1; 0; 0; 232; 3; 3 ] @ a_l @ a_l @ [ 0; 0; 2; 0; 0; 1; 0; 0; 189; 0; 0; 0; 185; 0; 183; 0; 0; 180; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111 ] ) ;
 
    (* this one is the smallest which needs extra padding
@@ -363,7 +363,7 @@ let handshake_assembler_tests =
                    client_random = a_cs <+> a_cs ;
                    sessionid = None ;
                    ciphersuites = [Packet.TLS_NULL_WITH_NULL_NULL] ;
-                   extensions = [Hostname (Some "foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofo")] },
+                   extensions = [`Hostname "foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofo"] },
      [ 1; 0; 1; 0xFC; 3; 3 ] @ a_l @ a_l @ [ 0; 0; 2; 0; 0; 1; 0; 1; 0xD3; 0; 0; 0; 0xD0; 0; 0xCE; 0; 0; 0xCB; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111; 0; 21; 0; 0xF9; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0  ] ) ;
 
    (* this one is the biggest which needs no extra padding *)
@@ -371,7 +371,7 @@ let handshake_assembler_tests =
                    client_random = a_cs <+> a_cs ;
                    sessionid = None ;
                    ciphersuites = [Packet.TLS_NULL_WITH_NULL_NULL] ;
-                   extensions = [Hostname (Some "foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoof")] },
+                   extensions = [`Hostname "foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoof"] },
      [ 1; 0; 0; 251; 3; 3 ] @ a_l @ a_l @ [ 0; 0; 2; 0; 0; 1; 0; 0; 208; 0; 0; 0; 204; 0; 202; 0; 0; 199; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102 ] ) ;
 
    (* this one is the biggest which needs no extra padding, and no exts *)
@@ -441,7 +441,7 @@ Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WI
                    server_random  = a_cs <+> a_cs ;
                    sessionid = None ;
                    ciphersuite = `TLS_RSA_WITH_RC4_128_MD5 ;
-                   extensions = [Hostname None]
+                   extensions = [`Hostname]
                  } ,
      [2; 0; 0; 44; 3; 3] @ a_l @ a_l @ [(* session id *) 0; (* cipher *) 0; 4; (* comp *) 0; (* exts *) 0; 4; 0; 0; 0; 0] ) ;
 
@@ -450,7 +450,7 @@ Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WI
                    server_random  = a_cs <+> a_cs ;
                    sessionid = None ;
                    ciphersuite = `TLS_RSA_WITH_RC4_128_MD5 ;
-                   extensions = [SecureRenegotiation (Cstruct.create 0)]
+                   extensions = [`SecureRenegotiation (Cstruct.create 0)]
                  } ,
      [2; 0; 0; 45; 3; 3] @ a_l @ a_l @ [(* session id *) 0; (* cipher *) 0; 4; (* comp *) 0; (* exts *) 0; 5; 0xFF; 1; 0; 1; 0] ) ;
 
@@ -458,7 +458,7 @@ Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WI
                    server_random  = a_cs <+> a_cs ;
                    sessionid = None ;
                    ciphersuite = `TLS_RSA_WITH_RC4_128_MD5 ;
-                   extensions = [Hostname None ; SecureRenegotiation (Cstruct.create 0)]
+                   extensions = [`Hostname ; `SecureRenegotiation (Cstruct.create 0)]
                  } ,
      [2; 0; 0; 49; 3; 3] @ a_l @ a_l @ [(* session id *) 0; (* cipher *) 0; 4; (* comp *) 0; (* exts *) 0; 9; 0; 0; 0; 0; 0xFF; 1; 0; 1; 0] ) ;
 
@@ -466,7 +466,7 @@ Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WI
                    server_random  = a_cs <+> a_cs ;
                    sessionid = None ;
                    ciphersuite = `TLS_RSA_WITH_RC4_128_MD5 ;
-                   extensions = [SecureRenegotiation (Cstruct.create 0); Hostname None]
+                   extensions = [`SecureRenegotiation (Cstruct.create 0); `Hostname ]
                  } ,
      [2; 0; 0; 49; 3; 3] @ a_l @ a_l @ [(* session id *) 0; (* cipher *) 0; 4; (* comp *) 0; (* exts *) 0; 9; 0xFF; 1; 0; 1; 0; 0; 0; 0; 0] ) ;
 

--- a/tests/writertests.ml
+++ b/tests/writertests.ml
@@ -273,44 +273,44 @@ let handshake_assembler_tests =
    ( Certificate [a_cs ; emp ; a_cs] , [ 11; 0; 0; 44; 0; 0; 41 ] @ le @ a_l @ [ 0; 0; 0 ] @ le @ a_l ) ;
    ( Certificate [a_cs ; emp ; a_cs ; emp] , [ 11; 0; 0; 47; 0; 0; 44 ] @ le @ a_l @ [ 0; 0; 0 ] @ le @ a_l @ [ 0; 0; 0 ] ) ;
 
-   ( ClientHello { version = Supported TLS_1_2 ;
-                   random = a_cs <+> a_cs ;
+   ( ClientHello { client_version = Supported TLS_1_2 ;
+                   client_random = a_cs <+> a_cs ;
                    sessionid = None ;
                    ciphersuites = [] ;
                    extensions = [] },
      [ 1; 0; 0; 39; 3; 3 ] @ a_l @ a_l @ [ 0; 0; 0; 1; 0 ] ) ;
 
-   ( ClientHello { version = Supported TLS_1_1 ;
-                   random = a_cs <+> a_cs ;
+   ( ClientHello { client_version = Supported TLS_1_1 ;
+                   client_random = a_cs <+> a_cs ;
                    sessionid = None ;
                    ciphersuites = [] ;
                    extensions = [] },
      [ 1; 0; 0; 39; 3; 2 ] @ a_l @ a_l @ [ 0; 0; 0; 1; 0 ] ) ;
 
-   ( ClientHello { version = Supported TLS_1_0 ;
-                   random = a_cs <+> a_cs ;
+   ( ClientHello { client_version = Supported TLS_1_0 ;
+                   client_random = a_cs <+> a_cs ;
                    sessionid = None ;
                    ciphersuites = [] ;
                    extensions = [] },
      [ 1; 0; 0; 39; 3; 1 ] @ a_l @ a_l @ [ 0; 0; 0; 1; 0 ] ) ;
 
-   ( ClientHello { version = Supported TLS_1_2 ;
-                   random = a_cs <+> a_cs ;
+   ( ClientHello { client_version = Supported TLS_1_2 ;
+                   client_random = a_cs <+> a_cs ;
                    sessionid = None ;
                    ciphersuites = [Packet.TLS_NULL_WITH_NULL_NULL] ;
                    extensions = [] },
      [ 1; 0; 0; 41; 3; 3 ] @ a_l @ a_l @ [ 0; 0; 2; 0; 0; 1; 0 ] ) ;
 
-   ( ClientHello { version = Supported TLS_1_2 ;
-                   random = a_cs <+> a_cs ;
+   ( ClientHello { client_version = Supported TLS_1_2 ;
+                   client_random = a_cs <+> a_cs ;
                    sessionid = None ;
                    ciphersuites = Packet.([TLS_NULL_WITH_NULL_NULL ; TLS_RSA_WITH_NULL_MD5 ; TLS_RSA_WITH_NULL_SHA ; TLS_RSA_EXPORT_WITH_RC4_40_MD5]);
                    extensions = [] },
      [ 1; 0; 0; 47; 3; 3 ] @ a_l @ a_l @ [ 0; 0; 8; 0; 0; 0; 1; 0; 2; 0; 3; 1; 0 ] ) ;
 
 
-   ( ClientHello { version = Supported TLS_1_2 ;
-                   random = a_cs <+> a_cs ;
+   ( ClientHello { client_version = Supported TLS_1_2 ;
+                   client_random = a_cs <+> a_cs ;
                    sessionid = None ;
                    ciphersuites = Packet.([TLS_NULL_WITH_NULL_NULL ; TLS_RSA_WITH_NULL_MD5 ; TLS_RSA_WITH_NULL_SHA ; TLS_RSA_EXPORT_WITH_RC4_40_MD5]);
                    extensions = [
@@ -336,22 +336,22 @@ let handshake_assembler_tests =
               0x00; 0x1e; 0x06; 0x01; 0x06; 0x02; 0x06; 0x03; 0x05; 0x01; 0x05; 0x02; 0x05; 0x03; 0x04; 0x01; 0x04; 0x02; 0x04; 0x03; 0x03; 0x01; 0x03; 0x02; 0x03; 0x03; 0x02; 0x01; 0x02; 0x02; 0x02; 0x03 ] ) ;
 
 
-   ( ClientHello { version = Supported TLS_1_2 ;
-                   random = a_cs <+> a_cs ;
+   ( ClientHello { client_version = Supported TLS_1_2 ;
+                   client_random = a_cs <+> a_cs ;
                    sessionid = None ;
                    ciphersuites = [Packet.TLS_NULL_WITH_NULL_NULL] ;
                    extensions = [Hostname (Some "foo")] },
      [ 1; 0; 0; 55; 3; 3 ] @ a_l @ a_l @ [ 0; 0; 2; 0; 0; 1; 0; 0; 12; 0; 0; 0; 8; 0; 6; 0; 0; 3; 102; 111; 111 ] ) ;
 
-   ( ClientHello { version = Supported TLS_1_2 ;
-                   random = a_cs <+> a_cs ;
+   ( ClientHello { client_version = Supported TLS_1_2 ;
+                   client_random = a_cs <+> a_cs ;
                    sessionid = None ;
                    ciphersuites = [Packet.TLS_NULL_WITH_NULL_NULL] ;
                    extensions = [Hostname (Some "foofoofoofoofoofoofoofoofoofoo")] },
      [ 1; 0; 0; 82; 3; 3 ] @ a_l @ a_l @ [ 0; 0; 2; 0; 0; 1; 0; 0; 39; 0; 0; 0; 35; 0; 33; 0; 0; 30; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111; 102; 111; 111 ] ) ;
 
-   ( ClientHello { version = Supported TLS_1_2 ;
-                   random = a_cs <+> a_cs ;
+   ( ClientHello { client_version = Supported TLS_1_2 ;
+                   client_random = a_cs <+> a_cs ;
                    sessionid = None ;
                    ciphersuites = [Packet.TLS_NULL_WITH_NULL_NULL] ;
                    extensions = [Hostname (Some "foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo")] },
@@ -359,24 +359,24 @@ let handshake_assembler_tests =
 
    (* this one is the smallest which needs extra padding
      (due to its size being > 256 and < 511) *)
-   ( ClientHello { version = Supported TLS_1_2 ;
-                   random = a_cs <+> a_cs ;
+   ( ClientHello { client_version = Supported TLS_1_2 ;
+                   client_random = a_cs <+> a_cs ;
                    sessionid = None ;
                    ciphersuites = [Packet.TLS_NULL_WITH_NULL_NULL] ;
                    extensions = [Hostname (Some "foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofo")] },
      [ 1; 0; 1; 0xFC; 3; 3 ] @ a_l @ a_l @ [ 0; 0; 2; 0; 0; 1; 0; 1; 0xD3; 0; 0; 0; 0xD0; 0; 0xCE; 0; 0; 0xCB; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111; 0; 21; 0; 0xF9; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0  ] ) ;
 
    (* this one is the biggest which needs no extra padding *)
-   ( ClientHello { version = Supported TLS_1_2 ;
-                   random = a_cs <+> a_cs ;
+   ( ClientHello { client_version = Supported TLS_1_2 ;
+                   client_random = a_cs <+> a_cs ;
                    sessionid = None ;
                    ciphersuites = [Packet.TLS_NULL_WITH_NULL_NULL] ;
                    extensions = [Hostname (Some "foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoof")] },
      [ 1; 0; 0; 251; 3; 3 ] @ a_l @ a_l @ [ 0; 0; 2; 0; 0; 1; 0; 0; 208; 0; 0; 0; 204; 0; 202; 0; 0; 199; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102;111;111; 102 ] ) ;
 
    (* this one is the biggest which needs no extra padding, and no exts *)
-   ( ClientHello { version = Supported TLS_1_2 ;
-                   random = a_cs <+> a_cs ;
+   ( ClientHello { client_version = Supported TLS_1_2 ;
+                   client_random = a_cs <+> a_cs ;
                    sessionid = None ;
                    ciphersuites = [Packet.TLS_NULL_WITH_NULL_NULL; Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL; Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL; Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL; Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL; Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL; Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL; Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL; Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;
 Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;
@@ -388,8 +388,8 @@ Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WI
   1; 0 ] ) ;
 
    (* add one more, and we get into padding no exts *)
-   ( ClientHello { version = Supported TLS_1_2 ;
-                   random = a_cs <+> a_cs ;
+   ( ClientHello { client_version = Supported TLS_1_2 ;
+                   client_random = a_cs <+> a_cs ;
                    sessionid = None ;
                    ciphersuites = [Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL; Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL; Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL; Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL; Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL; Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL; Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL; Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL; Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;
 Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;
@@ -404,68 +404,68 @@ Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WITH_NULL_NULL;Packet.TLS_NULL_WI
 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0; 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;
  ] ) ;
 
-   ( ServerHello { version = TLS_1_2 ;
-                   random  = a_cs <+> a_cs ;
+   ( ServerHello { server_version = TLS_1_2 ;
+                   server_random  = a_cs <+> a_cs ;
                    sessionid = None ;
-                   ciphersuites = `TLS_RSA_WITH_RC4_128_MD5 ;
+                   ciphersuite = `TLS_RSA_WITH_RC4_128_MD5 ;
                    extensions = []
                  } ,
      [2; 0; 0; 38; 3; 3] @ a_l @ a_l @ [(* session id *) 0; (* cipher *) 0; 4; (* comp *) 0; (* exts *)] ) ;
 
-   ( ServerHello { version = TLS_1_1 ;
-                   random  = a_cs <+> a_cs ;
+   ( ServerHello { server_version = TLS_1_1 ;
+                   server_random  = a_cs <+> a_cs ;
                    sessionid = None ;
-                   ciphersuites = `TLS_RSA_WITH_RC4_128_MD5 ;
+                   ciphersuite = `TLS_RSA_WITH_RC4_128_MD5 ;
                    extensions = []
                  } ,
      [2; 0; 0; 38; 3; 2] @ a_l @ a_l @ [(* session id *) 0; (* cipher *) 0; 4; (* comp *) 0; (* exts *)] ) ;
 
-   ( ServerHello { version = TLS_1_0 ;
-                   random  = a_cs <+> a_cs ;
+   ( ServerHello { server_version = TLS_1_0 ;
+                   server_random  = a_cs <+> a_cs ;
                    sessionid = None ;
-                   ciphersuites = `TLS_RSA_WITH_RC4_128_MD5 ;
+                   ciphersuite = `TLS_RSA_WITH_RC4_128_MD5 ;
                    extensions = []
                  } ,
      [2; 0; 0; 38; 3; 1] @ a_l @ a_l @ [(* session id *) 0; (* cipher *) 0; 4; (* comp *) 0; (* exts *)] ) ;
 
 
-   ( ServerHello { version = TLS_1_0 ;
-                   random  = a_cs <+> a_cs ;
+   ( ServerHello { server_version = TLS_1_0 ;
+                   server_random  = a_cs <+> a_cs ;
                    sessionid = Some a_cs ;
-                   ciphersuites = `TLS_RSA_WITH_RC4_128_MD5 ;
+                   ciphersuite = `TLS_RSA_WITH_RC4_128_MD5 ;
                    extensions = []
                  } ,
      [2; 0; 0; 54; 3; 1] @ a_l @ a_l @ (* session id *) [ 16 ] @ a_l @ [(* cipher *) 0; 4; (* comp *) 0; (* exts *)] ) ;
 
-   ( ServerHello { version = TLS_1_2 ;
-                   random  = a_cs <+> a_cs ;
+   ( ServerHello { server_version = TLS_1_2 ;
+                   server_random  = a_cs <+> a_cs ;
                    sessionid = None ;
-                   ciphersuites = `TLS_RSA_WITH_RC4_128_MD5 ;
+                   ciphersuite = `TLS_RSA_WITH_RC4_128_MD5 ;
                    extensions = [Hostname None]
                  } ,
      [2; 0; 0; 44; 3; 3] @ a_l @ a_l @ [(* session id *) 0; (* cipher *) 0; 4; (* comp *) 0; (* exts *) 0; 4; 0; 0; 0; 0] ) ;
 
 
-   ( ServerHello { version = TLS_1_2 ;
-                   random  = a_cs <+> a_cs ;
+   ( ServerHello { server_version = TLS_1_2 ;
+                   server_random  = a_cs <+> a_cs ;
                    sessionid = None ;
-                   ciphersuites = `TLS_RSA_WITH_RC4_128_MD5 ;
+                   ciphersuite = `TLS_RSA_WITH_RC4_128_MD5 ;
                    extensions = [SecureRenegotiation (Cstruct.create 0)]
                  } ,
      [2; 0; 0; 45; 3; 3] @ a_l @ a_l @ [(* session id *) 0; (* cipher *) 0; 4; (* comp *) 0; (* exts *) 0; 5; 0xFF; 1; 0; 1; 0] ) ;
 
-   ( ServerHello { version = TLS_1_2 ;
-                   random  = a_cs <+> a_cs ;
+   ( ServerHello { server_version = TLS_1_2 ;
+                   server_random  = a_cs <+> a_cs ;
                    sessionid = None ;
-                   ciphersuites = `TLS_RSA_WITH_RC4_128_MD5 ;
+                   ciphersuite = `TLS_RSA_WITH_RC4_128_MD5 ;
                    extensions = [Hostname None ; SecureRenegotiation (Cstruct.create 0)]
                  } ,
      [2; 0; 0; 49; 3; 3] @ a_l @ a_l @ [(* session id *) 0; (* cipher *) 0; 4; (* comp *) 0; (* exts *) 0; 9; 0; 0; 0; 0; 0xFF; 1; 0; 1; 0] ) ;
 
-   ( ServerHello { version = TLS_1_2 ;
-                   random  = a_cs <+> a_cs ;
+   ( ServerHello { server_version = TLS_1_2 ;
+                   server_random  = a_cs <+> a_cs ;
                    sessionid = None ;
-                   ciphersuites = `TLS_RSA_WITH_RC4_128_MD5 ;
+                   ciphersuite = `TLS_RSA_WITH_RC4_128_MD5 ;
                    extensions = [SecureRenegotiation (Cstruct.create 0); Hostname None]
                  } ,
      [2; 0; 0; 49; 3; 3] @ a_l @ a_l @ [(* session id *) 0; (* cipher *) 0; 4; (* comp *) 0; (* exts *) 0; 9; 0xFF; 1; 0; 1; 0; 0; 0; 0; 0] ) ;


### PR DESCRIPTION
e.g. a server must not sent any Hostname extension with an actual name, a client must sent some name in their Hostname extension.  A server may not send a SignatureAlgorithms extension, ...

This is a preparation for 1.3, where they differ even more (KeyShare of keyshareentry list vs KeyShare of keyshare ; PreSharedKey of psk_id list vs PreSharedKey of psk_id)