### PR TITLE
Implement V1_LWT.FLOW disconnect

### DIFF
--- a/mirage/tls_mirage.ml
+++ b/mirage/tls_mirage.ml
@@ -156,6 +156,13 @@ module Make (F : V1_LWT.FLOW) = struct
       FLOW.(write flow.flow buf >>= fun _ -> close flow.flow)
     | _           -> return_unit
 
+  let disconnect flow =
+    ( match flow.state with
+      | `Active tls ->
+        flow.state <- `Eof
+      | _ -> () );
+    FLOW.disconnect flow.flow
+
   let client_of_flow ?trace conf host flow =
     let (tls, init) = Tls.Engine.client conf in
     let tls_flow = {


### PR DESCRIPTION
`FLOW.close` should flush data and signal to the remote that no more data will be written.

`FLOW.disconnect` should disconnect from the flow immediately without signalling and possibly drop in-flight/in-buffer data.

`FLOW.close` should act like `Unix.shutdown` while `FLOW.disconnect` should act like `Unix.close`.

This patch implements `FLOW.disconnect` by setting any `Active` connection to `Eof` (hopefully the GC will deallocate it later) and calling `disconnect` on the underlying flow.

Related to [mirage/mirage#550]

Signed-off-by: David Scott dave@recoil.org
