### PR TITLE
Use PCLOCK / Ptime

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -55,8 +55,8 @@ Library "tls-mirage"
   FindlibParent   : tls
   Path            : mirage
   Modules         : Tls_mirage
-  BuildDepends    : x509, tls, mirage-types, ipaddr, lwt
-  XMETARequires   : x509, tls, mirage-types, ipaddr, lwt
+  BuildDepends    : x509, tls, mirage-types, ipaddr, lwt, ptime
+  XMETARequires   : x509, tls, mirage-types, ipaddr, lwt, ptime
 
 Executable "test_runner"
   Build          $: flag(tests)

--- a/mirage/tls_mirage.ml
+++ b/mirage/tls_mirage.ml
@@ -198,7 +198,7 @@ module Make (F : V1_LWT.FLOW) = struct
 
 end
 
-module X509 (KV : V1_LWT.KV_RO) (C : V1.CLOCK) = struct
+module X509 (KV : V1_LWT.KV_RO) (C : V1.PCLOCK) = struct
 
   let ca_roots_file = "ca-roots.crt"
   let default_cert  = "server"
@@ -216,10 +216,10 @@ module X509 (KV : V1_LWT.KV_RO) (C : V1.CLOCK) = struct
 
   open X509.Encoding.Pem
 
-  let authenticator kv = function
+  let authenticator kv clock = function
     | `Noop -> return X509.Authenticator.null
     | `CAs  ->
-        let time = C.time () in
+        let time = Ptime.v (C.now_d_ps clock) |> Ptime.to_float_s in
         read_full kv ca_roots_file
         >|= Certificate.of_pem_cstruct
         >|= X509.Authenticator.chain_of_trust ~time

--- a/mirage/tls_mirage.mli
+++ b/mirage/tls_mirage.mli
@@ -45,11 +45,11 @@ end
 
 
 (** X.509 handling given a key value store and a clock *)
-module X509 (KV : V1_LWT.KV_RO) (C : V1.CLOCK) : sig
-  (** [authenticator store typ] creates an [authenticator], either
+module X509 (KV : V1_LWT.KV_RO) (C : V1.PCLOCK) : sig
+  (** [authenticator store clock typ] creates an [authenticator], either
       using the given certificate authorities in the [store] or
       null. *)
-  val authenticator : KV.t -> [< `Noop | `CAs ] -> X509.Authenticator.a Lwt.t
+  val authenticator : KV.t -> C.t -> [< `Noop | `CAs ] -> X509.Authenticator.a Lwt.t
 
   (** [certificate store typ] unmarshals a certificate chain and
       private key material from the [store]. *)

--- a/opam
+++ b/opam
@@ -28,6 +28,7 @@ depends: [
   "nocrypto" {>= "0.5.3"}
   "x509" {>= "0.5.0"}
   "ounit" {test}
+  "ptime" {>= "0.8.1"} (* only necessary for mirage subpackage, but unable to express this here *)
 ]
 depopts: [
   "lwt"


### PR DESCRIPTION
I massaged the commits of #329 slightly: no need for `ptime` in `tls-lwt` right now, and add a dependency onto `ptime >= 0.8.1` (for `Ptime.v`) into the opam file.  This is only needed for the mirage subpackage, but we're not able to express this in opam (we could explicit create multiple packages (might be worth doing, but then we should also switch to `topkg`), or provide a new `mirage-no-mirage` (similar to `mirage-no-xen`/`mirage-no-solo5`) package (feels way to hacky)).

Travis CI will not succeed with mirage since it uses mirage as released into opam-repository (and I don't think there's much value in moving this towards mirage-dev branches).  Likely the example unikernels suffer from bitrot atm, but can be fixed in subsequent commits.

@mattgray I squashed your commits and amended the changes mentioned above.  hope that's fine with you.