### PR TITLE
don't require a peer name for client_of_fd, there's no need for this

### DIFF
--- a/lwt/tls_lwt.ml
+++ b/lwt/tls_lwt.ml
@@ -187,8 +187,11 @@ module Unix = struct
       tracer = trace ;
     }
 
-  let client_of_fd ?trace config ~host fd =
-    let config'     = Tls.Config.peer config host in
+  let client_of_fd ?trace config ?host fd =
+    let config' = match host with
+      | None -> config
+      | Some host -> Tls.Config.peer config host
+    in
     let (tls, init) = Tls.Engine.client config' in
     let t = {
       state  = `Active tls ;

--- a/lwt/tls_lwt.mli
+++ b/lwt/tls_lwt.mli
@@ -33,7 +33,7 @@ module Unix : sig
 
   (** [client_of_fd ?tracer client ~host fd] is [t], after client-side
       TLS handshake of [fd] using [client] configuration and [host]. *)
-  val client_of_fd : ?trace:tracer -> Tls.Config.client -> host:string -> Lwt_unix.file_descr -> t Lwt.t
+  val client_of_fd : ?trace:tracer -> Tls.Config.client -> ?host:string -> Lwt_unix.file_descr -> t Lwt.t
 
   (** [accept ?tracer server fd] is [t, sockaddr], after accepting a
       client on [fd] and upgrading to a TLS connection. *)

--- a/mirage/example/unikernel.ml
+++ b/mirage/example/unikernel.ml
@@ -117,7 +117,7 @@ struct
     >>= function
     | `Error e -> L.log_error c (S.TCPV4.error_message e)
     | `Ok tcp  ->
-        TLS.client_of_flow conf (snd peer) tcp
+        TLS.client_of_flow conf ~host:(snd peer) tcp
         >>== chat c
         >>= function
         | `Error e -> L.log_error c (TLS.error_message e)

--- a/mirage/tls_mirage.ml
+++ b/mirage/tls_mirage.ml
@@ -156,8 +156,12 @@ module Make (F : V1_LWT.FLOW) = struct
       FLOW.(write flow.flow buf >>= fun _ -> close flow.flow)
     | _           -> return_unit
 
-  let client_of_flow ?trace conf host flow =
-    let (tls, init) = Tls.Engine.client conf in
+  let client_of_flow ?trace conf ?host flow =
+    let conf' = match host with
+      | None -> conf
+      | Some host -> Tls.Config.peer conf host
+    in
+    let (tls, init) = Tls.Engine.client conf' in
     let tls_flow = {
       role   = `Client ;
       flow   = flow ;

--- a/mirage/tls_mirage.mli
+++ b/mirage/tls_mirage.mli
@@ -24,11 +24,10 @@ module Make (F : V1_LWT.FLOW) : sig
   (** [reneg flow] renegotiates the session. *)
   val reneg  : flow -> [ `Ok of unit | `Eof | `Error of error ] Lwt.t
 
-  (** [client_of_flow ?trace client hostname flow] upgrades the
-      existing connection to TLS using the [client] configuration and
-      given [hostname]. *)
+  (** [client_of_flow ~trace client ~host flow] upgrades the existing connection
+      to TLS using the [client] configuration, using [host] as peer name. *)
   val client_of_flow :
-    ?trace:tracer -> Tls.Config.client -> string -> FLOW.flow ->
+    ?trace:tracer -> Tls.Config.client -> ?host:string -> FLOW.flow ->
     [> `Ok of flow | `Error of error | `Eof ] Lwt.t
 
   (** [server_of_flow ?tracer server flow] upgrades the flow to a TLS


### PR DESCRIPTION
This is the low-level interface, and not all TLS scenarios require any form of name validation.

An example is a syslog server, we don't want to depend on DNS for syslog.  Authentication is done via a CA chain, but no name is compared.  See https://github.com/hannesm/logs-syslog/blob/32137a34e83e5a0ba6ba8c6e8da45957971de71e/src/logs_syslog_lwt.ml#L65