### PR TITLE
Update .merlin

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -4,6 +4,7 @@ S mirage
 
 B _build/**
 
+PKG lwt.unix
 PKG result
 PKG cstruct
 PKG sexplib
@@ -11,6 +12,3 @@ PKG nocrypto
 PKG x509
 PKG mirage-kv-lwt mirage-flow-lwt ptime mirage-clock
 PKG mirage-types-lwt mirage-types
-
-EXT sexplib
-EXT lwt


### PR DESCRIPTION
* syntax extensions are no longer used
* add lwt.unix to the list of findlib packages