### PR TITLE
opam updates, unbreak (client side) renegotiation with EMS, authentication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ script: bash -ex .travis-opam.sh
 env:
   global:
     - PACKAGE="tls"
-    - PINS="x509"
+    - PINS="x509:https://github.com/hannesm/ocaml-x509.git#newcrl"
   matrix:
     - OCAML_VERSION=4.02 DEPOPTS=lwt
     - OCAML_VERSION=4.03

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -215,7 +215,7 @@ let peer conf name = { conf with peer_name = Some name }
 let (<?>) ma b = match ma with None -> b | Some a -> a
 
 let client
-  ~authenticator ?ciphers ?version ?hashes ?reneg ?certificates ?cached_session () =
+  ~authenticator ?peer_name ?ciphers ?version ?hashes ?reneg ?certificates ?cached_session () =
   let config =
     { default_config with
         authenticator     = Some authenticator ;
@@ -224,6 +224,7 @@ let client
         hashes            = hashes        <?> default_config.hashes ;
         use_reneg         = reneg         <?> default_config.use_reneg ;
         own_certificates  = certificates  <?> default_config.own_certificates ;
+        peer_name         = peer_name ;
         cached_session    = cached_session ;
     } in
   ( validate_common config ; validate_client config ; config )

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -212,6 +212,8 @@ and of_client conf = conf
 
 let peer conf name = { conf with peer_name = Some name }
 
+let with_authenticator conf auth = { conf with authenticator = Some auth }
+
 let (<?>) ma b = match ma with None -> b | Some a -> a
 
 let client

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -129,3 +129,5 @@ val of_client : client -> config
 (** [of_server server] is a server configuration for [server] *)
 val of_server : server -> config
 
+(** [with_authenticator config auth] is [config] with [auth] as [authenticator] *)
+val with_authenticator : config -> X509.Authenticator.a -> config

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -48,10 +48,11 @@ val sexp_of_server : server -> Sexplib.Sexp.t
 
 (** {1 Constructors} *)
 
-(** [client authenticator ?ciphers ?version ?hashes ?reneg ?certificates] is [client] configuration with the given parameters.
+(** [client authenticator ?peer_name ?ciphers ?version ?hashes ?reneg ?certificates] is [client] configuration with the given parameters.
     @raise Invalid_argument if the configuration is invalid *)
 val client :
   authenticator   : X509.Authenticator.a ->
+  ?peer_name      : string ->
   ?ciphers        : Ciphersuite.ciphersuite list ->
   ?version        : tls_version * tls_version ->
   ?hashes         : Hash.hash list ->

--- a/lib/engine.ml
+++ b/lib/engine.ml
@@ -475,15 +475,20 @@ let send_application_data st css =
 
 let send_close_notify st = send_records st [Alert.close_notify]
 
-let reneg st =
-  let hs = st.handshake in
-  match hs.machina with
+let reneg ?authenticator st =
+  let handshake = match authenticator with
+    | None -> st.handshake
+    | Some auth ->
+      let hs = st.handshake in
+      { hs with config = Config.with_authenticator hs.config auth }
+  in
+  match handshake.machina with
   | Server Established ->
-     ( match Handshake_server.hello_request hs with
+     ( match Handshake_server.hello_request handshake with
        | Ok (handshake, [`Record hr]) -> Some (send_records { st with handshake } [hr])
        | _                            -> None )
   | Client Established ->
-     ( match Handshake_client.answer_hello_request hs with
+     ( match Handshake_client.answer_hello_request handshake with
        | Ok (handshake, [`Record ch]) -> Some (send_records { st with handshake } [ch])
        | _                            -> None )
   | _                        -> None

--- a/lib/engine.ml
+++ b/lib/engine.ml
@@ -458,6 +458,10 @@ let send_records (st : state) records =
 (* utility for user *)
 let can_handle_appdata s = hs_can_handle_appdata s.handshake
 
+let handshake_in_progress s = match s.handshake.machina with
+  | Client Established | Server Established -> false
+  | _ -> true
+
 (* another entry for user data *)
 let send_application_data st css =
   match can_handle_appdata st with

--- a/lib/engine.mli
+++ b/lib/engine.mli
@@ -150,11 +150,11 @@ val send_application_data : state -> Cstruct.t list -> (state * Cstruct.t) optio
     tls state, and out the (possible encrypted) close notify alert. *)
 val send_close_notify     : state -> state * Cstruct.t
 
-(** [reneg tls] initiates a renegotation on [tls]. It is [tls' * out]
-    where [tls'] is the new tls state, and [out] either a client hello
-    or hello request (depending on which communication endpoint [tls]
-    is). *)
-val reneg                 : state -> (state * Cstruct.t) option
+(** [reneg ~authenticator tls] initiates a renegotation on [tls], using the
+    provided [authenticator]. It is [tls' * out] where [tls'] is the new tls
+    state, and [out] either a client hello or hello request (depending on which
+    communication endpoint [tls] is). *)
+val reneg : ?authenticator:X509.Authenticator.a -> state -> (state * Cstruct.t) option
 
 (** {1 Session information} *)
 

--- a/lib/engine.mli
+++ b/lib/engine.mli
@@ -141,6 +141,10 @@ val handle_tls           : state -> Cstruct.t -> ret
     connection has already completed a handshake. *)
 val can_handle_appdata    : state -> bool
 
+(** [handshake_in_progrss state] is a predicate which indicates whether there
+    is a handshake in progress or scheduled. *)
+val handshake_in_progress : state -> bool
+
 (** [send_application_data tls outs] is [(tls' * out) option] where
     [tls'] is the new tls state, and [out] the cstruct to send over the
     wire (encrypted [outs]). *)

--- a/lwt/tls_lwt.ml
+++ b/lwt/tls_lwt.ml
@@ -154,12 +154,12 @@ module Unix = struct
           | `Eof     -> fail End_of_file
           | `Ok cs   -> push_linger t cs ; drain_handshake t
 
-  let reneg t =
+  let reneg ?authenticator t =
     match t.state with
     | `Error err  -> fail err
     | `Eof        -> fail @@ Invalid_argument "tls: closed socket"
     | `Active tls ->
-        match tracing t @@ fun () -> Tls.Engine.reneg tls with
+        match tracing t @@ fun () -> Tls.Engine.reneg ?authenticator tls with
         | None -> fail @@ Invalid_argument "tls: can't renegotiate"
         | Some (tls', buf) ->
            t.state <- `Active tls' ;

--- a/lwt/tls_lwt.mli
+++ b/lwt/tls_lwt.mli
@@ -71,7 +71,7 @@ module Unix : sig
   val close : t -> unit Lwt.t
 
   (** [reneg t] renegotiates the keys of the session. *)
-  val reneg : t -> unit Lwt.t
+  val reneg : ?authenticator:X509.Authenticator.a -> t -> unit Lwt.t
 
   (** [epoch t] returns [epoch], which contains information of the
       active session. *)

--- a/lwt/tls_lwt.mli
+++ b/lwt/tls_lwt.mli
@@ -70,8 +70,13 @@ module Unix : sig
   (** [close t] closes the TLS session and the underlying file descriptor. *)
   val close : t -> unit Lwt.t
 
-  (** [reneg t] renegotiates the keys of the session. *)
-  val reneg : ?authenticator:X509.Authenticator.a -> t -> unit Lwt.t
+  (** [reneg ~authenticator ~drop t] renegotiates the keys of the session, and
+      blocks until the renegotiation finished.  Optionally, a new
+      [authenticator] can be used.  If [drop] is [true] (the default),
+      application data received before the renegotiation finished is dropped.
+      If [drop] is [false], application data received in between is available by
+      calling [read] after [reneg] returned. *)
+  val reneg : ?authenticator:X509.Authenticator.a -> ?drop:bool -> t -> unit Lwt.t
 
   (** [epoch t] returns [epoch], which contains information of the
       active session. *)

--- a/mirage/tls_mirage.ml
+++ b/mirage/tls_mirage.ml
@@ -243,7 +243,7 @@ module X509 (KV : Mirage_kv_lwt.RO) (C: Mirage_clock.PCLOCK) = struct
         let time = Ptime.v (C.now_d_ps clock) in
         read_full kv ca_roots_file
         >|= Certificate.of_pem_cstruct
-        >|= X509.Authenticator.chain_of_trust ~time
+        >|= X509.Authenticator.chain_of_trust ~time ?crls:None
 
   let certificate kv =
     let read name =


### PR DESCRIPTION
My motivation behind these changes is to allow the scenario where the client should authenticate, but transmit its certificate only over an encrypted connection.  The way to do this is (from the server side, since the server has to choose that it needs an authenticated client) to establish a (only server-authenticated) TLS connection, switch the authenticator in place (to send out a CertificateRequest in the next handshake), and then ask the client to renegotiate the connection (by sending a HelloRequest).

While implementing, I found an issue (since 0.7.0 / summer 2015) which avoided our client code from renegotiating if the ExtendedMasterSecret extension is used (fixed in a4783c5).

The design of `Tls_lwt.reneg` was far from finished, esp. with recent changes (23 Jan 2016) to `can_handle_appdata` (and its usage in `Tls_lwt.reneg` around 1 Jul 2014) lead that it returned too early (before the renegotiation was finished).  The commit bb4186a reintroduces a `handshake_in_progress` which is used in `drain_handshake` for looping.

The semantics of `reneg` needed another tweak, since application data is allowed between the HelloRequest and the ClientHello, what to do with it.  There are two choices: retain or drop.  Drop is the new default, and an optional parameter is introduced.  This allows server code to reason about the epoch application data arrived -- or to ensure within server code that data received in the last epoch is discarded.