### PR TITLE
Implement server acceptable certificate auths

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -28,6 +28,7 @@ type config = {
   authenticator     : X509.Authenticator.a option ;
   peer_name         : string option ;
   own_certificates  : own_cert ;
+  acceptable_cas    : X509.distinguished_name list ;
   session_cache     : session_cache ;
   cached_session    : epoch_data option ;
 } [@@deriving sexp]
@@ -89,6 +90,7 @@ let default_config = {
   authenticator     = None ;
   peer_name         = None ;
   own_certificates  = `None ;
+  acceptable_cas    = [] ;
   session_cache     = (fun _ -> None) ;
   cached_session    = None ;
 }
@@ -230,16 +232,17 @@ let client
   ( validate_common config ; validate_client config ; config )
 
 let server
-  ?ciphers ?version ?hashes ?reneg ?certificates ?authenticator ?session_cache () =
+  ?ciphers ?version ?hashes ?reneg ?certificates ?acceptable_cas ?authenticator ?session_cache () =
   let config =
     { default_config with
-        ciphers           = ciphers       <?> default_config.ciphers ;
-        protocol_versions = version       <?> default_config.protocol_versions ;
-        hashes            = hashes        <?> default_config.hashes ;
-        use_reneg         = reneg         <?> default_config.use_reneg ;
-        own_certificates  = certificates  <?> default_config.own_certificates ;
+        ciphers           = ciphers        <?> default_config.ciphers ;
+        protocol_versions = version        <?> default_config.protocol_versions ;
+        hashes            = hashes         <?> default_config.hashes ;
+        use_reneg         = reneg          <?> default_config.use_reneg ;
+        own_certificates  = certificates   <?> default_config.own_certificates ;
+        acceptable_cas    = acceptable_cas <?> default_config.acceptable_cas ;
         authenticator     = authenticator ;
-        session_cache     = session_cache <?> default_config.session_cache ;
+        session_cache     = session_cache  <?> default_config.session_cache ;
     } in
   ( validate_common config ; validate_server config ; config )
 

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -27,6 +27,7 @@ type config = private {
   authenticator     : X509.Authenticator.a option ; (** optional X509 authenticator *)
   peer_name         : string option ; (** optional name of other endpoint (used for SNI RFC4366) *)
   own_certificates  : own_cert ; (** optional default certificate chain and other certificate chains *)
+  acceptable_cas    : X509.distinguished_name list ; (** ordered list of acceptable certificate authorities *)
   session_cache     : session_cache ;
   cached_session    : epoch_data option ;
 }
@@ -61,16 +62,17 @@ val client :
   ?cached_session : epoch_data ->
   unit -> client
 
-(** [server ?ciphers ?version ?hashes ?reneg ?certificates ?authenticator] is [server] configuration with the given parameters.
+(** [server ?ciphers ?version ?hashes ?reneg ?certificates ?acceptable_cas ?authenticator] is [server] configuration with the given parameters.
     @raise Invalid_argument if the configuration is invalid *)
 val server :
-  ?ciphers       : Ciphersuite.ciphersuite list ->
-  ?version       : tls_version * tls_version ->
-  ?hashes        : Hash.hash list ->
-  ?reneg         : bool ->
-  ?certificates  : own_cert ->
-  ?authenticator : X509.Authenticator.a ->
-  ?session_cache : session_cache ->
+  ?ciphers        : Ciphersuite.ciphersuite list ->
+  ?version        : tls_version * tls_version ->
+  ?hashes         : Hash.hash list ->
+  ?reneg          : bool ->
+  ?certificates   : own_cert ->
+  ?acceptable_cas : X509.distinguished_name list ->
+  ?authenticator  : X509.Authenticator.a ->
+  ?session_cache  : session_cache ->
   unit -> server
 
 (** [peer client name] is [client] with [name] as [peer_name] *)

--- a/lib/handshake_server.ml
+++ b/lib/handshake_server.ml
@@ -238,14 +238,18 @@ let answer_client_hello_common state reneg ch raw =
     match config.authenticator with
     | None -> ([], session)
     | Some _ ->
-       (* TODO: extract DN from authenticator and send to client *)
+       let cas =
+         List.map X509.Encoding.cs_of_distinguished_name config.acceptable_cas
+       in
        let certreq = match version with
          | TLS_1_0 | TLS_1_1 ->
-            let data = assemble_certificate_request [Packet.RSA_SIGN] [] in
+            let data = assemble_certificate_request [Packet.RSA_SIGN] cas in
             CertificateRequest data
          | TLS_1_2 ->
             let sigalgs = List.map (fun h -> (h, Packet.RSA)) config.hashes in
-            let data = assemble_certificate_request_1_2 [Packet.RSA_SIGN] sigalgs [] in
+            let data =
+              assemble_certificate_request_1_2 [Packet.RSA_SIGN] sigalgs cas
+            in
             CertificateRequest data
        in
        (* Tracing.sexpf ~tag:"handshake-out" ~f:sexp_of_tls_handshake certreq ; *)


### PR DESCRIPTION
The code for acceptable certificate authorities in a client certificate
request was already implemented, but handshake_server.ml had hardcoded
an empty list of CAs. This commit adds a configuration option for this.

this is #332 rebased (and amended) on master.  it also uses `X509.distinguished_name list` instead of `X509.t list` (and thus needs X509 master which provides the sexp conversion of `distinguished_name`) and renames `accepted_cas` to `acceptable_cas`.