### PR TITLE
compatibility with ppx_sexp_conv > v0.11.0

### DIFF
--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -1,0 +1,20 @@
+open Ocamlbuild_plugin
+
+let runtime_deps_of_ppx ppx =
+  (Findlib.query "ppx_sexp_conv").dependencies
+  |> List.filter_opt (fun { Findlib.name; _ } ->
+      if name = ppx || name = "ppx_deriving" then
+        None
+      else
+        Some name)
+
+let () = dispatch (function
+    | After_rules ->
+      let meta = "pkg/META" in
+      let meta_in = meta ^ ".in" in
+      rule meta ~dep:meta_in ~prod:meta (fun _ _ ->
+          let deps = String.concat " " (runtime_deps_of_ppx "ppx_sexp_conv") in
+          Echo([String.subst "PPX_SEXP_CONV_RUNTIME" deps
+                  (Pathname.read meta_in)],
+               meta))
+    | _ -> ())

--- a/opam
+++ b/opam
@@ -24,7 +24,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "ppx_sexp_conv" {build & < "v0.11.0"}
+  "ppx_sexp_conv"
   "ppx_deriving" {build}
   "ppx_cstruct" {build & >= "3.0.0"}
   "result"
@@ -48,6 +48,7 @@ conflicts: [
   "mirage-net-xen" {<"1.3.0"}
   "mirage-types" {<"3.0.0"}
   "sexplib" {= "v0.9.0"}
+  "ppx_sexp_conv" {= "v0.11.0"}
   "ptime" {< "0.8.1"}
 ]
 

--- a/pkg/META.in
+++ b/pkg/META.in
@@ -1,6 +1,6 @@
 version = "%%VERSION_NUM%%"
 description = "Transport layer security (TLS 1.x) purely in OCaml"
-requires = "cstruct sexplib result nocrypto x509"
+requires = "cstruct sexplib result nocrypto x509 PPX_SEXP_CONV_RUNTIME"
 archive(byte) = "tls.cma"
 plugin(byte) = "tls.cma"
 archive(native) = "tls.cmxa"


### PR DESCRIPTION
this applies the same trick as nocrypto for figuring out runtime dependencies of ppx_sexp_conv, and thus allows interoperability with recent releases (v0.11.x series apart from .0 which has a runtime dependency on base)