### PR TITLE
Don't try writing to the remote if we got `EOF`

### DIFF
--- a/lwt/tls_lwt.ml
+++ b/lwt/tls_lwt.ml
@@ -82,7 +82,10 @@ module Unix = struct
             | `Alert a -> `Error (Tls_alert a)
           in
           t.state <- state' ;
-          (resp |> when_some (write_t t)) >>= fun () -> return (`Ok data)
+          if state' = `Eof then
+            return (`Ok data)
+          else
+            (resp |> when_some (write_t t)) >>= fun () -> return (`Ok data)
 
       | `Fail (alert, `Response resp) ->
           t.state <- `Error (Tls_failure alert) ;


### PR DESCRIPTION
This should fix #347 and is an alternative to #371.

I was receiving EPIPE signals in my code that caused the last chunk sent
by the server to never get in my application.

After some investigation, I realized that, in `Tls_lwt.Unix.read_react`,
the library tries to write a response (if there's one) on the socket.
However, in the case that the state is EOF, writing this response will
throw SIGPIPE and never deliver the received data to the calling code.

The proposed fix is to not even try to write this response in case we
got EOF from the socket.