### PR TITLE
Tls_lwt: delay error from writing to peer while reading.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+## 0.9.3 (2019-01-07)
+
+* tls: do not require client sent ciphersuites to be a proper set
+  (interoperability with some android devices)
+* tls_lwt: delay error from writing to peer while reading, record errors only
+  if state is active (fixes #347)
+* migrate opam file to opam 2.0 format
+
 ## 0.9.2 (2018-08-24)
 
 * compatibility with ppx_sexp_conv >v0.11.0 (#381), required for 4.07.0

--- a/lwt/tls_lwt.ml
+++ b/lwt/tls_lwt.ml
@@ -54,8 +54,9 @@ module Unix = struct
     let recording_errors op t cs =
       Lwt.catch
         (fun () -> op t.fd cs)
-        (fun exn ->
-           t.state <- `Error exn ;
+        (fun exn -> (match t.state with
+             | `Error _ | `Eof -> ()
+             | `Active _ -> t.state <- `Error exn) ;
            fail exn)
     in
     (recording_errors Lwt_cs.read, recording_errors Lwt_cs.write_full)

--- a/lwt/tls_lwt.ml
+++ b/lwt/tls_lwt.ml
@@ -82,7 +82,8 @@ module Unix = struct
             | `Alert a -> `Error (Tls_alert a)
           in
           t.state <- state' ;
-          (resp |> when_some (write_t t)) >>= fun () -> return (`Ok data)
+          safely (resp |> when_some (write_t t)) >|= fun () ->
+          `Ok data
 
       | `Fail (alert, `Response resp) ->
           t.state <- `Error (Tls_failure alert) ;


### PR DESCRIPTION
previously, if handle_tls returned a response to the peer, write was called,
which may error out (recording it's error in the state and Lwt.fail). the
received data was never returned to the caller.

now, similar to the semantics in tls_mirage, the error from write is only
recorded in the state, and returned on the next function call (write/..).

should fix #347, alternative to #371, #387 -- could you please test this @edwintorok @anmonteiro @rymdhund //cc @pqwy