### PR TITLE
lib: do not require the list of ciphersuites sent by the client to be a proper set

### DIFF
--- a/lib/handshake_common.ml
+++ b/lib/handshake_common.ml
@@ -125,8 +125,10 @@ let client_hello_valid ch =
   not (empty ch.ciphersuites)
   &&
 
+  (* android 4.4 and davdroid do not send proper sets!
   (List_set.is_proper_set ch.ciphersuites)
   &&
+  *)
 
   (* TODO: if ecc ciphersuite, require ellipticcurves and ecpointformats extensions! *)
   List_set.is_proper_set (extension_types to_client_ext_type ch.extensions)

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -30,4 +30,5 @@ let () =
     Pkg.test ~run:false ~cond:lwt "lwt/examples/echo_client_alpn" ;
     Pkg.test ~run:false ~cond:lwt "lwt/examples/test_server" ;
     Pkg.test ~run:false ~cond:lwt "lwt/examples/test_client" ;
+    Pkg.test ~run:false ~cond:lwt "lwt/examples/http_client" ;
   ]


### PR DESCRIPTION
this fixes interoperability with (at least) android 4.4 devices