### PR TITLE
plumbing for the next release

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -4,7 +4,7 @@ S mirage
 
 B _build/**
 
-PKG cstruct nocrypto result x509 sexplib
+PKG cstruct nocrypto x509 sexplib
 PKG cstruct.ppx ppx_sexp_conv
 PKG oUnit cstruct.unix
 PKG lwt lwt.unix str nocrypto.lwt

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ env:
     - PACKAGE="tls"
     - PINS="x509"
   matrix:
-    - OCAML_VERSION=4.02 DEPOPTS="lwt ptime astring"
     - OCAML_VERSION=4.03
     - OCAML_VERSION=4.04
     - OCAML_VERSION=4.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,15 @@ env:
   matrix:
     - OCAML_VERSION=4.03
     - OCAML_VERSION=4.04
-    - OCAML_VERSION=4.04
-      DEPOPTS="mirage-flow-lwt mirage-kv-lwt mirage-clock ptime"
-      POST_INSTALL_HOOK="./.travis-test-mirage.sh" TESTS=false
     - OCAML_VERSION=4.05 DEPOPTS="lwt ptime astring"
     - OCAML_VERSION=4.05
       DEPOPTS="mirage-flow-lwt mirage-kv-lwt mirage-clock ptime"
       POST_INSTALL_HOOK="./.travis-test-mirage.sh" TESTS=false
     - OCAML_VERSION=4.06
     - OCAML_VERSION=4.06 DEPOPTS="lwt ptime astring"
+    - OCAML_VERSION=4.06
+      DEPOPTS="mirage-flow-lwt mirage-kv-lwt mirage-clock ptime"
+      POST_INSTALL_HOOK="./.travis-test-mirage.sh" TESTS=false
     - OCAML_VERSION=4.07
     - OCAML_VERSION=4.07
       DEPOPTS="mirage-flow-lwt mirage-kv-lwt mirage-clock ptime"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ env:
     - PACKAGE="tls"
     - PINS="x509"
   matrix:
-    - OCAML_VERSION=4.03
     - OCAML_VERSION=4.04
     - OCAML_VERSION=4.05 DEPOPTS="lwt ptime astring"
     - OCAML_VERSION=4.05

--- a/_tags
+++ b/_tags
@@ -1,6 +1,6 @@
 true : color(always), bin_annot, safe_string
 true : warn(+A-4-9-41-42-44-45)
-true : package(cstruct cstruct-sexp nocrypto result x509 sexplib)
+true : package(cstruct cstruct-sexp nocrypto x509 sexplib)
 
 <lib/*.ml> : for-pack(Tls)
 <lib/packet.ml> : package(ppx_cstruct)
@@ -22,3 +22,5 @@ true : package(cstruct cstruct-sexp nocrypto result x509 sexplib)
 <mirage/*> : package(mirage-flow-lwt mirage-kv-lwt mirage-clock lwt ptime)
 
 <random>: -traverse
+<mirage/example>: -traverse
+<mirage/example2>: -traverse

--- a/_tags
+++ b/_tags
@@ -1,6 +1,6 @@
 true : color(always), bin_annot, safe_string
 true : warn(+A-4-9-41-42-44-45)
-true : package(cstruct nocrypto result x509 sexplib)
+true : package(cstruct cstruct-sexp nocrypto result x509 sexplib)
 
 <lib/*.ml> : for-pack(Tls)
 <lib/packet.ml> : package(ppx_cstruct)

--- a/lib/control.ml
+++ b/lib/control.ml
@@ -1,5 +1,3 @@
-open Result
-
 (*
  * Monad core
  *)

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -67,7 +67,7 @@ type tls_hdr = {
 } [@@deriving sexp]
 
 module SessionID = struct
-  type t = Cstruct.t [@@deriving sexp]
+  type t = Cstruct_sexp.t [@@deriving sexp]
   let compare = Cstruct.compare
   let hash t = Hashtbl.hash (Cstruct.to_bigarray t)
   let equal = Cstruct.equal
@@ -78,10 +78,10 @@ type client_extension = [
   | `MaxFragmentLength of max_fragment_length
   | `EllipticCurves of named_curve_type list
   | `ECPointFormats of ec_point_format list
-  | `SecureRenegotiation of Cstruct.t
+  | `SecureRenegotiation of Cstruct_sexp.t
   | `Padding of int
   | `SignatureAlgorithms of (Hash.hash * signature_algorithm_type) list
-  | `UnknownExtension of (int * Cstruct.t)
+  | `UnknownExtension of (int * Cstruct_sexp.t)
   | `ExtendedMasterSecret
   | `ALPN of string list
 ] [@@deriving sexp]
@@ -90,15 +90,15 @@ type server_extension = [
   | `Hostname
   | `MaxFragmentLength of max_fragment_length
   | `ECPointFormats of ec_point_format list
-  | `SecureRenegotiation of Cstruct.t
-  | `UnknownExtension of (int * Cstruct.t)
+  | `SecureRenegotiation of Cstruct_sexp.t
+  | `UnknownExtension of (int * Cstruct_sexp.t)
   | `ExtendedMasterSecret
   | `ALPN of string
 ] [@@deriving sexp]
 
 type client_hello = {
   client_version : tls_any_version;
-  client_random  : Cstruct.t;
+  client_random  : Cstruct_sexp.t;
   sessionid      : SessionID.t option;
   ciphersuites   : any_ciphersuite list;
   extensions     : client_extension list
@@ -106,47 +106,47 @@ type client_hello = {
 
 type server_hello = {
   server_version : tls_version;
-  server_random  : Cstruct.t;
+  server_random  : Cstruct_sexp.t;
   sessionid      : SessionID.t option;
   ciphersuite    : ciphersuite;
   extensions     : server_extension list
 } [@@deriving sexp]
 
 type dh_parameters = {
-  dh_p  : Cstruct.t;
-  dh_g  : Cstruct.t;
-  dh_Ys : Cstruct.t;
+  dh_p  : Cstruct_sexp.t;
+  dh_g  : Cstruct_sexp.t;
+  dh_Ys : Cstruct_sexp.t;
 } [@@deriving sexp]
 
 type ec_curve = {
-  a : Cstruct.t;
-  b : Cstruct.t
+  a : Cstruct_sexp.t;
+  b : Cstruct_sexp.t
 } [@@deriving sexp]
 
 type ec_prime_parameters = {
-  prime    : Cstruct.t;
+  prime    : Cstruct_sexp.t;
   curve    : ec_curve;
-  base     : Cstruct.t;
-  order    : Cstruct.t;
-  cofactor : Cstruct.t;
-  public   : Cstruct.t
+  base     : Cstruct_sexp.t;
+  order    : Cstruct_sexp.t;
+  cofactor : Cstruct_sexp.t;
+  public   : Cstruct_sexp.t
 } [@@deriving sexp]
 
 type ec_char_parameters = {
   m        : int;
   basis    : ec_basis_type;
-  ks       : Cstruct.t list;
+  ks       : Cstruct_sexp.t list;
   curve    : ec_curve;
-  base     : Cstruct.t;
-  order    : Cstruct.t;
-  cofactor : Cstruct.t;
-  public   : Cstruct.t
+  base     : Cstruct_sexp.t;
+  order    : Cstruct_sexp.t;
+  cofactor : Cstruct_sexp.t;
+  public   : Cstruct_sexp.t
 } [@@deriving sexp]
 
 type ec_parameters =
   | ExplicitPrimeParameters of ec_prime_parameters
   | ExplicitCharParameters of ec_char_parameters
-  | NamedCurveParameters of (named_curve_type * Cstruct.t)
+  | NamedCurveParameters of (named_curve_type * Cstruct_sexp.t)
   [@@deriving sexp]
 
 type tls_handshake =
@@ -154,12 +154,12 @@ type tls_handshake =
   | ServerHelloDone
   | ClientHello of client_hello
   | ServerHello of server_hello
-  | Certificate of Cstruct.t list
-  | ServerKeyExchange of Cstruct.t
-  | CertificateRequest of Cstruct.t
-  | ClientKeyExchange of Cstruct.t
-  | CertificateVerify of Cstruct.t
-  | Finished of Cstruct.t
+  | Certificate of Cstruct_sexp.t list
+  | ServerKeyExchange of Cstruct_sexp.t
+  | CertificateRequest of Cstruct_sexp.t
+  | ClientKeyExchange of Cstruct_sexp.t
+  | CertificateVerify of Cstruct_sexp.t
+  | Finished of Cstruct_sexp.t
   [@@deriving sexp]
 
 type tls_alert = alert_level * alert_type [@@deriving sexp]
@@ -172,19 +172,19 @@ type tls_body =
   [@@deriving sexp]
 
 (** the master secret of a TLS connection *)
-type master_secret = Cstruct.t [@@deriving sexp]
+type master_secret = Cstruct_sexp.t [@@deriving sexp]
 
 (** information about an open session *)
 type epoch_data = {
   protocol_version       : tls_version ;
   ciphersuite            : Ciphersuite.ciphersuite ;
-  peer_random            : Cstruct.t ;
+  peer_random            : Cstruct_sexp.t ;
   peer_certificate_chain : X509.t list ;
   peer_certificate       : X509.t option ;
   peer_name              : string option ;
   trust_anchor           : X509.t option ;
   received_certificates  : X509.t list ;
-  own_random             : Cstruct.t ;
+  own_random             : Cstruct_sexp.t ;
   own_certificate        : X509.t list ;
   own_private_key        : Nocrypto.Rsa.priv option ;
   own_name               : string option ;

--- a/lib/engine.ml
+++ b/lib/engine.ml
@@ -101,7 +101,7 @@ let new_state config role =
     fragment  = Cstruct.create 0 ;
   }
 
-type raw_record = tls_hdr * Cstruct.t [@@deriving sexp]
+type raw_record = tls_hdr * Cstruct_sexp.t [@@deriving sexp]
 
 (* well-behaved pure encryptor *)
 let encrypt (version : tls_version) (st : crypto_state) ty buf =

--- a/lib/reader.ml
+++ b/lib/reader.ml
@@ -15,7 +15,7 @@ type error =
   [@@deriving sexp]
 
 include Control.Or_error_make (struct type err = error end)
-type 'a result = ('a, error) Result.result
+type nonrec 'a result = ('a, error) result
 
 exception Reader_error of error
 

--- a/lib/reader.mli
+++ b/lib/reader.mli
@@ -11,7 +11,7 @@ type error =
 val error_of_sexp : Sexplib.Sexp.t -> error
 val sexp_of_error : error -> Sexplib.Sexp.t
 
-type 'a result = ('a, error) Result.result
+type nonrec 'a result = ('a, error) result
 
 val parse_version     : Cstruct.t -> Core.tls_version result
 val parse_any_version : Cstruct.t -> Core.tls_any_version result

--- a/lib/state.ml
+++ b/lib/state.ml
@@ -219,4 +219,3 @@ type failure = [
 (* Monadic control-flow core. *)
 include Control.Or_error_make (struct type err = failure end)
 type 'a eff = 'a t
-include Result

--- a/lib/tracing.ml
+++ b/lib/tracing.ml
@@ -27,6 +27,6 @@ let sexpf ~tag ~f x = sexp ~tag @@ lazy (f x)
 
 let sexpfs ~tag ~f xs = if is_tracing () then List.iter (sexpf ~tag ~f) xs
 
-let cs ~tag = sexpf ~tag ~f:Cstruct.sexp_of_t
+let cs ~tag = sexpf ~tag ~f:Cstruct_sexp.sexp_of_t
 
 let css ~tag css = if is_tracing () then List.iter (cs ~tag) css

--- a/mirage/example2/config.ml
+++ b/mirage/example2/config.ml
@@ -3,10 +3,9 @@ open Mirage
 let secrets_dir = "sekrit"
 
 let disk  = direct_kv_ro secrets_dir
-and stack = socket_stackv4 [Ipaddr.V4.any]
+and stack = generic_stackv4 default_network
 
 let packages = [
-  package "mirage-clock-unix" ;
   package "cohttp-mirage" ;
   package ~min:"0.99" "cohttp-lwt" ;
   package ~sublibs:["mirage"] "tls" ;

--- a/mirage/tls_mirage.ml
+++ b/mirage/tls_mirage.ml
@@ -1,5 +1,4 @@
 open Lwt
-open Result
 
 module Make (F : Mirage_flow_lwt.S) = struct
 

--- a/mirage/tls_mirage.mli
+++ b/mirage/tls_mirage.mli
@@ -1,7 +1,5 @@
 (** Effectful operations using Mirage for pure TLS. *)
 
-open Result
-
 (** TLS module given a flow *)
 module Make (F : Mirage_flow_lwt.S) : sig
 

--- a/opam
+++ b/opam
@@ -19,7 +19,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.04.2"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}

--- a/opam
+++ b/opam
@@ -27,7 +27,8 @@ depends: [
   "ppx_deriving"
   "ppx_cstruct" {>= "3.0.0"}
   "result"
-  "cstruct" {>= "3.0.0"}
+  "cstruct" {>= "4.0.0"}
+  "cstruct-sexp"
   "sexplib"
   "nocrypto" {>= "0.5.4"}
   "x509" {>= "0.6.1"}

--- a/opam
+++ b/opam
@@ -26,7 +26,6 @@ depends: [
   "ppx_sexp_conv"
   "ppx_deriving"
   "ppx_cstruct" {>= "3.0.0"}
-  "result"
   "cstruct" {>= "4.0.0"}
   "cstruct-sexp"
   "sexplib"

--- a/opam
+++ b/opam
@@ -19,7 +19,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.02.2"}
+  "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}

--- a/pkg/META.in
+++ b/pkg/META.in
@@ -1,6 +1,6 @@
 version = "%%VERSION_NUM%%"
 description = "Transport layer security (TLS 1.x) purely in OCaml"
-requires = "cstruct sexplib result nocrypto x509 PPX_SEXP_CONV_RUNTIME"
+requires = "cstruct cstruct-sexp sexplib result nocrypto x509 PPX_SEXP_CONV_RUNTIME"
 archive(byte) = "tls.cma"
 plugin(byte) = "tls.cma"
 archive(native) = "tls.cmxa"

--- a/pkg/META.in
+++ b/pkg/META.in
@@ -1,6 +1,6 @@
 version = "%%VERSION_NUM%%"
 description = "Transport layer security (TLS 1.x) purely in OCaml"
-requires = "cstruct cstruct-sexp sexplib result nocrypto x509 PPX_SEXP_CONV_RUNTIME"
+requires = "cstruct cstruct-sexp sexplib nocrypto x509 PPX_SEXP_CONV_RUNTIME"
 archive(byte) = "tls.cma"
 plugin(byte) = "tls.cma"
 archive(native) = "tls.cmxa"

--- a/tests/readertests.ml
+++ b/tests/readertests.ml
@@ -1,4 +1,3 @@
-open Result
 open Tls
 open OUnit2
 open Testlib

--- a/tests/readerwritertests.ml
+++ b/tests/readerwritertests.ml
@@ -1,4 +1,3 @@
-open Result
 open Tls
 open OUnit2
 open Testlib


### PR DESCRIPTION
- support for cstruct 4.0.0+
- remove support for < 4.04.2 (same as x509 in master)
- remove result (part of 4.03.0)
- enhance mirage/example2 to work on more platforms than unix