### PR TITLE
adapt to X509 0.7.0 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ env:
     - PINS="x509"
   matrix:
     - OCAML_VERSION=4.04
-    - OCAML_VERSION=4.05 DEPOPTS="lwt ptime astring"
+    - OCAML_VERSION=4.05 DEPOPTS="lwt ptime"
     - OCAML_VERSION=4.05
       DEPOPTS="mirage-flow-lwt mirage-kv-lwt mirage-clock ptime"
       POST_INSTALL_HOOK="./.travis-test-mirage.sh" TESTS=false
     - OCAML_VERSION=4.06
-    - OCAML_VERSION=4.06 DEPOPTS="lwt ptime astring"
+    - OCAML_VERSION=4.06 DEPOPTS="lwt ptime"
     - OCAML_VERSION=4.06
       DEPOPTS="mirage-flow-lwt mirage-kv-lwt mirage-clock ptime"
       POST_INSTALL_HOOK="./.travis-test-mirage.sh" TESTS=false

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## 0.10.3 (2019-07-26)
+
+* support x509 0.7.0+
+* remove dependency on Astring (was only used in the lwt-starttls example)
+
 ## 0.10.2 (2019-04-02)
 
 * support for cstruct 4.0.0+

--- a/_tags
+++ b/_tags
@@ -1,6 +1,6 @@
 true : color(always), bin_annot, safe_string
 true : warn(+A-4-9-41-42-44-45)
-true : package(cstruct cstruct-sexp nocrypto x509 sexplib)
+true : package(cstruct cstruct-sexp nocrypto x509 sexplib domain-name fmt)
 
 <lib/*.ml> : for-pack(Tls)
 <lib/packet.ml> : package(ppx_cstruct)
@@ -17,7 +17,7 @@ true : package(cstruct cstruct-sexp nocrypto x509 sexplib)
 
 <lwt/**/*> : package(lwt lwt.unix ptime.clock.os)
 <lwt> : include
-<lwt/examples/*> : package(astring nocrypto.lwt)
+<lwt/examples/*> : package(nocrypto.lwt)
 
 <mirage/*> : package(mirage-flow-lwt mirage-kv-lwt mirage-clock lwt ptime)
 

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -6,7 +6,7 @@ open Core
 open Sexplib.Std
 
 
-type certchain = X509.t list * Rsa.priv [@@deriving sexp]
+type certchain = Cert.t list * Rsa.priv [@@deriving sexp]
 
 type own_cert = [
   | `None
@@ -19,16 +19,28 @@ type session_cache = SessionID.t -> epoch_data option
 let session_cache_of_sexp _ = fun _ -> None
 let sexp_of_session_cache _ = Sexplib.Sexp.Atom "SESSION_CACHE"
 
+module Auth = struct
+  type t = X509.Authenticator.t
+  let t_of_sexp _ = failwith "can't convert sexp to authenticator"
+  let sexp_of_t _ = Sexplib.Sexp.Atom "Authenticator"
+end
+
+module DN = struct
+  type t = X509.Distinguished_name.t
+  let t_of_sexp _ = failwith "can't convert sexp to distinguished name"
+  let sexp_of_t _ = Sexplib.Sexp.Atom "distinguished name"
+end
+
 type config = {
   ciphers           : Ciphersuite.ciphersuite list ;
   protocol_versions : tls_version * tls_version ;
   hashes            : Hash.hash list ;
   (* signatures        : Packet.signature_algorithm_type list ; *)
   use_reneg         : bool ;
-  authenticator     : X509.Authenticator.a option ;
+  authenticator     : Auth.t option ;
   peer_name         : string option ;
   own_certificates  : own_cert ;
-  acceptable_cas    : X509.distinguished_name list ;
+  acceptable_cas    : DN.t list ;
   session_cache     : session_cache ;
   cached_session    : epoch_data option ;
   alpn_protocols    : string list ;
@@ -119,7 +131,7 @@ let validate_common config =
     invalid "alpn protocols list too large"
 
 module CertTypeUsageOrdered = struct
-  type t = X509.key_type * X509.Extension.key_usage
+  type t = X509.Certificate.key_type * X509.Extension.key_usage
   let compare = compare
 end
 module CertTypeUsageSet = Set.Make(CertTypeUsageOrdered)
@@ -129,16 +141,17 @@ let validate_certificate_chain = function
      let pub = Rsa.pub_of_priv priv in
      if Rsa.pub_bits pub < min_rsa_key_size then
        invalid "RSA key too short!" ;
-     ( match X509.public_key s with
+     ( match X509.Certificate.public_key s with
        | `RSA pub' when pub = pub' -> ()
        | _ -> invalid "public / private key combination" ) ;
      ( match init_and_last chain with
        | Some (ch, trust) ->
          (* TODO: verify that certificates are x509 v3 if TLS_1_2 *)
          ( match X509.Validation.verify_chain_of_trust ~anchors:[trust] (s :: ch) with
-           | `Ok _   -> ()
-           | `Fail x -> invalid ("certificate chain does not validate: " ^
-                                 (X509.Validation.validation_error_to_string x)) )
+           | Ok _   -> ()
+           | Error x ->
+             let s = Fmt.to_to_string X509.Validation.pp_validation_error x in
+             invalid ("certificate chain does not validate: " ^ s))
        | None -> () )
   | _ -> invalid "certificate"
 
@@ -148,22 +161,17 @@ let validate_client config =
   | `Single c -> validate_certificate_chain c
   | _ -> invalid_arg "multiple client certificates not supported in client config"
 
-module StringSet = Set.Make(String)
-
 let non_overlapping cs =
   let namessets =
-    let nameslists =
-      filter_map cs ~f:(function
-          | (s :: _, _) -> Some s
-          | _           -> None)
-      |> List.map X509.hostnames
-    in
-    List.map (fun xs -> List.fold_right StringSet.add xs StringSet.empty) nameslists
+    filter_map cs ~f:(function
+        | (s :: _, _) -> Some s
+        | _           -> None)
+    |> List.map X509.Certificate.hostnames
   in
   let rec check = function
     | []    -> ()
     | s::ss -> if not (List.for_all
-                         (fun ss' -> StringSet.is_empty (StringSet.inter s ss'))
+                         (fun ss' -> Domain_name.Set.is_empty (Domain_name.Set.inter s ss'))
                          ss)
                then
                  invalid_arg "overlapping names in certificates"
@@ -198,8 +206,8 @@ let validate_server config =
     not (CertTypeUsageSet.for_all
            (fun (t, u) ->
               List.exists (fun c ->
-                  X509.supports_keytype c t &&
-                  X509.Extension.supports_usage ~not_present:true c u)
+                  X509.Certificate.supports_keytype c t &&
+                  supports_key_usage ~not_present:true c u)
                 server_certs)
            typeusage)
   then

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -6,7 +6,7 @@ open Core
 (** {1 Config type} *)
 
 (** certificate chain and private key of the first certificate *)
-type certchain = X509.t list * Nocrypto.Rsa.priv
+type certchain = Cert.t list * Nocrypto.Rsa.priv
 
 (** polymorphic variant of own certificates *)
 type own_cert = [
@@ -24,10 +24,10 @@ type config = private {
   protocol_versions : tls_version * tls_version ; (** supported protocol versions (min, max) *)
   hashes            : Hash.hash list ; (** ordered list of supported hash algorithms (regarding preference) *)
   use_reneg         : bool ; (** endpoint should accept renegotiation requests *)
-  authenticator     : X509.Authenticator.a option ; (** optional X509 authenticator *)
+  authenticator     : X509.Authenticator.t option ; (** optional X509 authenticator *)
   peer_name         : string option ; (** optional name of other endpoint (used for SNI RFC4366) *)
   own_certificates  : own_cert ; (** optional default certificate chain and other certificate chains *)
-  acceptable_cas    : X509.distinguished_name list ; (** ordered list of acceptable certificate authorities *)
+  acceptable_cas    : X509.Distinguished_name.t list ; (** ordered list of acceptable certificate authorities *)
   session_cache     : session_cache ;
   cached_session    : epoch_data option ;
   alpn_protocols    : string list ; (** optional ordered list of accepted alpn_protocols *)
@@ -54,7 +54,7 @@ val sexp_of_server : server -> Sexplib.Sexp.t
     [client] configuration with the given parameters.
     @raise Invalid_argument if the configuration is invalid *)
 val client :
-  authenticator   : X509.Authenticator.a ->
+  authenticator   : X509.Authenticator.t ->
   ?peer_name      : string ->
   ?ciphers        : Ciphersuite.ciphersuite list ->
   ?version        : tls_version * tls_version ->
@@ -74,8 +74,8 @@ val server :
   ?hashes         : Hash.hash list ->
   ?reneg          : bool ->
   ?certificates   : own_cert ->
-  ?acceptable_cas : X509.distinguished_name list ->
-  ?authenticator  : X509.Authenticator.a ->
+  ?acceptable_cas : X509.Distinguished_name.t list ->
+  ?authenticator  : X509.Authenticator.t ->
   ?session_cache  : session_cache ->
   ?alpn_protocols : string list ->
   unit -> server
@@ -146,10 +146,10 @@ val of_client : client -> config
 val of_server : server -> config
 
 (** [with_authenticator config auth] is [config] with [auth] as [authenticator] *)
-val with_authenticator : config -> X509.Authenticator.a -> config
+val with_authenticator : config -> X509.Authenticator.t -> config
 
 (** [with_own_certificates config cert] is [config] with [cert] as [own_cert] *)
 val with_own_certificates : config -> own_cert -> config
 
 (** [with_acceptable_cas config cas] is [config] with [cas] as [accepted_cas] *)
-val with_acceptable_cas : config -> X509.distinguished_name list -> config
+val with_acceptable_cas : config -> X509.Distinguished_name.t list -> config

--- a/lib/engine.ml
+++ b/lib/engine.ml
@@ -65,7 +65,9 @@ let alert_of_failure = function
   | `Fatal x -> alert_of_fatal x
 
 let string_of_failure = function
-  | `Error (`AuthenticationFailure v) -> "authentication failure: " ^ X509.Validation.validation_error_to_string v
+  | `Error (`AuthenticationFailure v) ->
+    let s = Fmt.to_to_string X509.Validation.pp_validation_error v in
+    "authentication failure: " ^ s
   | f -> Sexplib.Sexp.to_string_hum (sexp_of_failure f)
 
 type ret = [

--- a/lib/engine.mli
+++ b/lib/engine.mli
@@ -159,8 +159,8 @@ val send_close_notify     : state -> state * Cstruct.t
     [tls], using the provided [authenticator]. It is [tls' * out] where [tls']
     is the new tls state, and [out] either a client hello or hello request
     (depending on which communication endpoint [tls] is). *)
-val reneg : ?authenticator:X509.Authenticator.a ->
-  ?acceptable_cas:X509.distinguished_name list -> ?cert:Config.own_cert ->
+val reneg : ?authenticator:X509.Authenticator.t ->
+  ?acceptable_cas:X509.Distinguished_name.t list -> ?cert:Config.own_cert ->
   state -> (state * Cstruct.t) option
 
 (** {1 Session information} *)

--- a/lib/handshake_common.ml
+++ b/lib/handshake_common.ml
@@ -9,8 +9,17 @@ let empty = function [] -> true | _ -> false
 let change_cipher_spec =
   (Packet.CHANGE_CIPHER_SPEC, Writer.assemble_change_cipher_spec)
 
-let hostname (h : client_hello) : string option =
-  map_find ~f:(function `Hostname s -> Some s | _ -> None) h.extensions
+let host_name_opt = function
+  | None   -> None
+  | Some x -> match Domain_name.of_string x with
+    | Error _ -> None
+    | Ok domain -> match Domain_name.host domain with
+      | Error _ -> None
+      | Ok host -> Some host
+
+let hostname (h : client_hello) : [ `host ] Domain_name.t option =
+  host_name_opt
+    (map_find ~f:(function `Hostname s -> Some s | _ -> None) h.extensions)
 
 let get_secure_renegotiation exts =
   map_find
@@ -169,14 +178,14 @@ let signature version data sig_algs hashes private_key =
         | None      -> fail (`Error (`NoConfiguredHash client_hashes))
         | Some hash -> return hash ) >|= fun hash_algo ->
     let hash = Hash.digest hash_algo data in
-    let cs = X509.Encoding.pkcs1_digest_info_to_cstruct (hash_algo, hash) in
+    let cs = X509.Certificate.encode_pkcs1_digest_info (hash_algo, hash) in
     let sign = Rsa.PKCS1.sig_encode ~key:private_key cs in
     Writer.assemble_digitally_signed_1_2 hash_algo Packet.RSA sign
 
 let peer_rsa_key = function
   | None -> fail (`Fatal `NoCertificateReceived)
   | Some cert ->
-    match X509.public_key cert with
+    match X509.Certificate.public_key cert with
     | `RSA key -> return key
     | _        -> fail (`Fatal `NotRSACertificate)
 
@@ -198,8 +207,8 @@ let verify_digitally_signed version hashes data signature_data certificate =
         | Ok (hash_algo, Packet.RSA, signature) ->
           guard (List.mem hash_algo hashes) (`Error (`NoConfiguredHash hashes)) >>= fun () ->
           let compare_hashes should data =
-            match X509.Encoding.pkcs1_digest_info_of_cstruct should with
-            | Some (hash_algo', target) when hash_algo = hash_algo' ->
+            match X509.Certificate.decode_pkcs1_digest_info should with
+            | Ok (hash_algo', target) when hash_algo = hash_algo' ->
               guard (Crypto.digest_eq hash_algo ~target data) (`Fatal `RSASignatureMismatch)
             | _ -> fail (`Fatal `HashAlgorithmMismatch)
           in
@@ -221,19 +230,22 @@ let verify_digitally_signed version hashes data signature_data certificate =
 let validate_chain authenticator certificates hostname =
   let authenticate authenticator host certificates =
     match authenticator ?host certificates with
-    | `Fail err  -> fail (`Error (`AuthenticationFailure err))
-    | `Ok anchor -> return anchor
+    | Error err  -> fail (`Error (`AuthenticationFailure err))
+    | Ok anchor -> return anchor
 
   and key_size min cs =
     let check c =
-      match X509.public_key c with
+      match X509.Certificate.public_key c with
       | `RSA key when Rsa.pub_bits key >= min -> true
       | _                                     -> false
     in
     guard (List.for_all check cs) (`Fatal `KeyTooSmall)
 
   and parse_certificates certs =
-    let certificates = filter_map ~f:X509.Encoding.parse certs in
+    let certificates =
+      let f cs = match X509.Certificate.decode_der cs with Ok c -> Some c | _ -> None in
+      filter_map ~f certs
+    in
     guard (List.length certs = List.length certificates) (`Fatal `BadCertificateChain) >|= fun () ->
     certificates
 

--- a/lib/state.ml
+++ b/lib/state.ml
@@ -78,11 +78,11 @@ type session_data = {
   client_random          : Cstruct_sexp.t ; (* 32 bytes random from the client hello *)
   client_version         : tls_any_version ; (* version in client hello (needed in RSA client key exchange) *)
   ciphersuite            : Ciphersuite.ciphersuite ;
-  peer_certificate_chain : X509.t list ;
-  peer_certificate       : X509.t option ;
-  trust_anchor           : X509.t option ;
-  received_certificates  : X509.t list ;
-  own_certificate        : X509.t list ;
+  peer_certificate_chain : Cert.t list ;
+  peer_certificate       : Cert.t option ;
+  trust_anchor           : Cert.t option ;
+  received_certificates  : Cert.t list ;
+  own_certificate        : Cert.t list ;
   own_private_key        : Nocrypto.Rsa.priv option ;
   master_secret          : master_secret ;
   renegotiation          : reneg_params ; (* renegotiation data *)
@@ -164,8 +164,16 @@ type state = {
   fragment  : Cstruct_sexp.t ; (* the leftover fragment from TCP fragmentation *)
 } [@@deriving sexp]
 
+module V_err = struct
+  type t = X509.Validation.validation_error
+  let t_of_sexp _ = failwith "couldn't convert validatin error from sexp"
+  let sexp_of_t v =
+    let s = Fmt.to_to_string X509.Validation.pp_validation_error v in
+    Sexplib.Sexp.Atom s
+end
+
 type error = [
-  | `AuthenticationFailure of X509.Validation.validation_error
+  | `AuthenticationFailure of V_err.t
   | `NoConfiguredCiphersuite of Ciphersuite.ciphersuite list
   | `NoConfiguredVersion of tls_version
   | `NoConfiguredHash of Hash.hash list

--- a/lwt/examples/http_client.ml
+++ b/lwt/examples/http_client.ml
@@ -6,7 +6,7 @@ let http_client ?ca ?fp host port =
   let port          = int_of_string port in
   X509_lwt.authenticator
     ( match ca, fp with
-      | None, Some fp  -> `Hex_key_fingerprints (`SHA256, [(host, fp)])
+      | None, Some fp  -> `Hex_key_fingerprints (`SHA256, [(Domain_name.of_string_exn host, fp)])
       | None, _        -> `Ca_dir ca_cert_dir
       | Some "NONE", _ -> `No_authentication_I'M_STUPID
       | Some f, _      -> `Ca_file f ) >>= fun authenticator ->

--- a/lwt/examples/starttls_server.ml
+++ b/lwt/examples/starttls_server.ml
@@ -37,9 +37,11 @@ let start_server () =
     return buff
   in
   let parse buff =
-    match Astring.String.cut ~sep:" " buff with
-    | None -> "", ""
-    | Some r -> r
+    match String.index buff ' ' with
+    | exception Not_found -> "", ""
+    | idx ->
+      let l = String.length buff in
+      String.sub buff 0 idx, String.sub buff (succ idx) (l - succ idx)
   in
   let rec wait_cmd sock_cl ic oc =
     read ic >>= fun buff ->

--- a/lwt/tls_lwt.mli
+++ b/lwt/tls_lwt.mli
@@ -75,8 +75,8 @@ module Unix : sig
       [authenticator] and [acceptable_cas] can be used.  The own certificate can
       be adjusted by [cert]. If [drop] is [true] (the default),
       application data received before the renegotiation finished is dropped. *)
-  val reneg : ?authenticator:X509.Authenticator.a ->
-    ?acceptable_cas:X509.distinguished_name list -> ?cert:Tls.Config.own_cert ->
+  val reneg : ?authenticator:X509.Authenticator.t ->
+    ?acceptable_cas:X509.Distinguished_name.t list -> ?cert:Tls.Config.own_cert ->
     ?drop:bool -> t -> unit Lwt.t
 
   (** [epoch t] returns [epoch], which contains information of the

--- a/lwt/x509_lwt.mli
+++ b/lwt/x509_lwt.mli
@@ -1,10 +1,10 @@
 (** X.509 certificate handling using Lwt. *)
 
 (** private material: a certificate chain and a RSA private key *)
-type priv          = X509.t list * Nocrypto.Rsa.priv
+type priv          = X509.Certificate.t list * Nocrypto.Rsa.priv
 
 (** authenticator *)
-type authenticator = X509.Authenticator.a
+type authenticator = X509.Authenticator.t
 
 (** [private_of_pems ~cert ~priv_key] is [priv], after reading the
     private key and certificate chain from the given PEM-encoded
@@ -13,18 +13,18 @@ val private_of_pems : cert:Lwt_io.file_name -> priv_key:Lwt_io.file_name -> priv
 
 (** [certs_of_pem file] is [certificates], which are read from the
     PEM-encoded [file]. *)
-val certs_of_pem     : Lwt_io.file_name -> X509.t list Lwt.t
+val certs_of_pem     : Lwt_io.file_name -> X509.Certificate.t list Lwt.t
 
 (** [certs_of_pem_dir dir] is [certificates], which are read from all
     PEM-encoded files in [dir]. *)
-val certs_of_pem_dir : Lwt_io.file_name -> X509.t list Lwt.t
+val certs_of_pem_dir : Lwt_io.file_name -> X509.Certificate.t list Lwt.t
 
 (** [authenticator methods] constructs an [authenticator] using the
     specified method and data. *)
 val authenticator :
   [ `Ca_file of Lwt_io.file_name
   | `Ca_dir  of Lwt_io.file_name
-  | `Key_fingerprints of Nocrypto.Hash.hash * (string * Cstruct.t) list
-  | `Hex_key_fingerprints of Nocrypto.Hash.hash * (string * string) list
+  | `Key_fingerprints of Nocrypto.Hash.hash * ('a Domain_name.t * Cstruct.t) list
+  | `Hex_key_fingerprints of Nocrypto.Hash.hash * ('a Domain_name.t * string) list
   | `No_authentication_I'M_STUPID ]
   -> authenticator Lwt.t

--- a/mirage/tls_mirage.mli
+++ b/mirage/tls_mirage.mli
@@ -33,8 +33,8 @@ module Make (F : Mirage_flow_lwt.S) : sig
       [authenticator] and [acceptable_cas] can be used.  The own certificate can
       be adjusted by [cert]. If [drop] is [true] (the default),
       application data received before the renegotiation finished is dropped. *)
-  val reneg : ?authenticator:X509.Authenticator.a ->
-    ?acceptable_cas:X509.distinguished_name list -> ?cert:Tls.Config.own_cert ->
+  val reneg : ?authenticator:X509.Authenticator.t ->
+    ?acceptable_cas:X509.Distinguished_name.t list -> ?cert:Tls.Config.own_cert ->
     ?drop:bool -> flow -> (unit, write_error) result Lwt.t
 
   (** [client_of_flow ~trace client ~host flow] upgrades the existing connection
@@ -61,10 +61,10 @@ module X509 (KV : Mirage_kv_lwt.RO) (C : Mirage_clock.PCLOCK) : sig
   (** [authenticator store clock typ] creates an [authenticator], either
       using the given certificate authorities in the [store] or
       null. *)
-  val authenticator : KV.t -> C.t -> [< `Noop | `CAs ] -> X509.Authenticator.a Lwt.t
+  val authenticator : KV.t -> C.t -> [< `Noop | `CAs ] -> X509.Authenticator.t Lwt.t
 
   (** [certificate store typ] unmarshals a certificate chain and
       private key material from the [store]. *)
   val certificate   : KV.t -> [< `Default | `Name of string ]
-                           -> (X509.t list * Nocrypto.Rsa.priv) Lwt.t
+                           -> (X509.Certificate.t list * Nocrypto.Rsa.priv) Lwt.t
 end

--- a/opam
+++ b/opam
@@ -13,7 +13,7 @@ build: [
     "--with-lwt" "%{lwt+ptime:installed}%"
     "--with-mirage" "%{mirage-flow-lwt+mirage-kv-lwt+mirage-clock+ptime:installed}%" ]
   ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"
-    "--with-lwt" "%{lwt+ptime+astring:installed}%"
+    "--with-lwt" "%{lwt+ptime:installed}%"
     "--with-mirage" "%{mirage-flow-lwt+mirage-kv-lwt+mirage-clock+ptime:installed}%" ] {with-test}
   ["ocaml" "pkg/pkg.ml" "test"] {with-test}
 ]
@@ -30,7 +30,9 @@ depends: [
   "cstruct-sexp"
   "sexplib"
   "nocrypto" {>= "0.5.4"}
-  "x509" {>= "0.6.1"}
+  "x509" {>= "0.7.0"}
+  "domain-name" {>= "0.3.0"}
+  "fmt"
   "cstruct-unix" {with-test & >= "3.0.0"}
   "ounit" {with-test}
 ]
@@ -40,7 +42,6 @@ depopts: [
   "mirage-kv-lwt"
   "mirage-clock"
   "ptime"
-  "astring" {with-test}
 ]
 conflicts: [
   "lwt" {<"2.4.8"}

--- a/pkg/META.in
+++ b/pkg/META.in
@@ -1,6 +1,6 @@
 version = "%%VERSION_NUM%%"
 description = "Transport layer security (TLS 1.x) purely in OCaml"
-requires = "cstruct cstruct-sexp sexplib nocrypto x509 PPX_SEXP_CONV_RUNTIME"
+requires = "cstruct cstruct-sexp sexplib nocrypto x509 domain-name fmt PPX_SEXP_CONV_RUNTIME"
 archive(byte) = "tls.cma"
 plugin(byte) = "tls.cma"
 archive(native) = "tls.cmxa"

--- a/tests/feedback.ml
+++ b/tests/feedback.ml
@@ -70,7 +70,12 @@ let loop_chatter ~certificate ~loops ~size =
 let load_priv () =
   let cs1 = Testlib.cs_mmap "./certificates/server.pem"
   and cs2 = Testlib.cs_mmap "./certificates/server.key" in
-  X509.Encoding.Pem.(Certificate.of_pem_cstruct cs1, match Private_key.of_pem_cstruct1 cs2 with `RSA key -> key)
+  match
+    X509.Certificate.decode_pem_multiple cs1, X509.Private_key.decode_pem cs2
+  with
+  | Ok certs, Ok (`RSA key) -> certs, key
+  | Error (`Msg m), _ -> failwith ("can't parse certificates " ^ m)
+  | _, Error (`Msg m) -> failwith ("can't parse private key " ^ m)
 
 let _ =
   let loops =


### PR DESCRIPTION
this is a minimal set of changes for the new X509 API. orthogonal changes (such as removing Tracing/sexp/switiching build system/use Domain_name.t instead of string) can be addressed separately