### PR TITLE
X509.0.9.0: hash_whitelist and expose crl support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ env:
   global:
     - PACKAGE="tls"
   matrix:
-    - OCAML_VERSION=4.04
     - OCAML_VERSION=4.05 DEPOPTS="lwt ptime"
     - OCAML_VERSION=4.06
     - OCAML_VERSION=4.07

--- a/_tags
+++ b/_tags
@@ -17,7 +17,7 @@ true : package(cstruct cstruct-sexp nocrypto x509 sexplib domain-name fmt)
 
 <lwt/**/*> : package(lwt lwt.unix ptime.clock.os)
 <lwt> : include
-<lwt/examples/*> : package(nocrypto.lwt)
+<lwt/examples/*> : package(nocrypto.lwt), thread
 
 <mirage/*> : package(mirage-flow mirage-kv mirage-clock lwt ptime)
 

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -170,13 +170,14 @@ let non_overlapping cs =
   in
   let rec check = function
     | []    -> ()
-    | s::ss -> if not (List.for_all
-                         (fun ss' -> Domain_name.Set.is_empty (Domain_name.Set.inter s ss'))
-                         ss)
-               then
-                 invalid_arg "overlapping names in certificates"
-               else
-                 check ss
+    | s::ss ->
+      if not (List.for_all (fun ss' ->
+          X509.Certificate.Host_set.is_empty (X509.Certificate.Host_set.inter s ss'))
+          ss)
+      then
+        invalid_arg "overlapping names in certificates"
+      else
+        check ss
   in
   check namessets
 

--- a/lib/handshake_client.ml
+++ b/lib/handshake_client.ml
@@ -150,11 +150,7 @@ let validate_keytype_usage certificate ciphersuite =
 
 let answer_certificate_RSA state session cs raw log =
   let cfg = state.config in
-  let peer_name = match host_name_opt cfg.peer_name with
-    | None -> None
-    | Some x -> Some (`Wildcard, x)
-  in
-  validate_chain cfg.authenticator cs peer_name >>= fun (peer_certificate, received_certificates, peer_certificate_chain, trust_anchor) ->
+  validate_chain cfg.authenticator cs (host_name_opt cfg.peer_name) >>= fun (peer_certificate, received_certificates, peer_certificate_chain, trust_anchor) ->
   validate_keytype_usage peer_certificate session.ciphersuite >>= fun () ->
   let session = { session with received_certificates ; peer_certificate ; peer_certificate_chain ; trust_anchor } in
   ( match session.client_version with
@@ -174,11 +170,8 @@ let answer_certificate_RSA state session cs raw log =
   ({ state with machina = Client machina }, [])
 
 let answer_certificate_DHE_RSA state session cs raw log =
-  let peer_name = match host_name_opt state.config.peer_name with
-    | None -> None
-    | Some x -> Some (`Wildcard, x)
-  in
-  validate_chain state.config.authenticator cs peer_name >>= fun (peer_certificate, received_certificates, peer_certificate_chain, trust_anchor) ->
+  let cfg = state.config in
+  validate_chain cfg.authenticator cs (host_name_opt cfg.peer_name) >>= fun (peer_certificate, received_certificates, peer_certificate_chain, trust_anchor) ->
   validate_keytype_usage peer_certificate session.ciphersuite >|= fun () ->
   let session = { session with received_certificates ; peer_certificate ; peer_certificate_chain ; trust_anchor } in
   let machina = AwaitServerKeyExchange_DHE_RSA (session, log @ [raw]) in

--- a/lib/handshake_server.ml
+++ b/lib/handshake_server.ml
@@ -139,13 +139,11 @@ let rec find_matching host certs =
 
 let agreed_cert certs hostname =
   let match_host ?default host certs =
-     match find_matching (`Strict, host) certs with
-     | Some x -> return x
-     | None   -> match find_matching (`Wildcard, host) certs with
-                 | Some x -> return x
-                 | None   -> match default with
-                             | Some c -> return c
-                             | None   -> fail (`Error (`NoMatchingCertificateFound (Domain_name.to_string host)))
+    match find_matching host certs with
+    | Some x -> return x
+    | None   -> match default with
+      | Some c -> return c
+      | None   -> fail (`Error (`NoMatchingCertificateFound (Domain_name.to_string host)))
   in
   match certs, hostname with
   | `None                    , _      -> fail (`Error `NoCertificateConfigured)

--- a/lwt/x509_lwt.mli
+++ b/lwt/x509_lwt.mli
@@ -21,10 +21,12 @@ val certs_of_pem_dir : Lwt_io.file_name -> X509.Certificate.t list Lwt.t
 
 (** [authenticator methods] constructs an [authenticator] using the
     specified method and data. *)
-val authenticator :
+val authenticator : ?hash_whitelist:Nocrypto.Hash.hash list -> ?crls:Lwt_io.file_name ->
   [ `Ca_file of Lwt_io.file_name
   | `Ca_dir  of Lwt_io.file_name
-  | `Key_fingerprints of Nocrypto.Hash.hash * ('a Domain_name.t * Cstruct.t) list
-  | `Hex_key_fingerprints of Nocrypto.Hash.hash * ('a Domain_name.t * string) list
+  | `Key_fingerprints of Nocrypto.Hash.hash * ([`host] Domain_name.t * Cstruct.t) list
+  | `Hex_key_fingerprints of Nocrypto.Hash.hash * ([`host] Domain_name.t * string) list
+  | `Cert_fingerprints of Nocrypto.Hash.hash * ([`host] Domain_name.t * Cstruct.t) list
+  | `Hex_cert_fingerprints of Nocrypto.Hash.hash * ([`host] Domain_name.t * string) list
   | `No_authentication_I'M_STUPID ]
   -> authenticator Lwt.t

--- a/mirage/tls_mirage.mli
+++ b/mirage/tls_mirage.mli
@@ -56,10 +56,15 @@ end
 
 (** X.509 handling given a key value store and a clock *)
 module X509 (KV : Mirage_kv.RO) (C : Mirage_clock.PCLOCK) : sig
-  (** [authenticator store clock typ] creates an [authenticator], either
-      using the given certificate authorities in the [store] or
-      null. *)
-  val authenticator : KV.t -> [< `Noop | `CAs ] -> X509.Authenticator.t Lwt.t
+  (** [authenticator ~hash_whitelist ~crl store typ] creates an [authenticator],
+      either using the given certificate authorities in the [store] as
+      value for key "ca_roots.crt", or null. If [hash_whitelist] is provided,
+      only these hashes are allowed for signatures of the certificate chain.
+      If [crl] is provided, the corresponding file is read and used as
+      revocation list (DER encoded). Both options only apply if [`CAs] is used.
+ *)
+  val authenticator : ?hash_whitelist:Nocrypto.Hash.hash list -> ?crl:string ->
+    KV.t -> [< `Noop | `CAs ] -> X509.Authenticator.t Lwt.t
 
   (** [certificate store typ] unmarshals a certificate chain and
       private key material from the [store]. *)

--- a/mirage/tls_mirage.mli
+++ b/mirage/tls_mirage.mli
@@ -59,7 +59,7 @@ module X509 (KV : Mirage_kv.RO) (C : Mirage_clock.PCLOCK) : sig
   (** [authenticator ~hash_whitelist ~crl store typ] creates an [authenticator],
       either using the given certificate authorities in the [store] as
       value for key "ca_roots.crt", or null. If [hash_whitelist] is provided,
-      only these hashes are allowed for signatures of the certificate chain.
+      only these hash algorithms are allowed for signatures of the certificate chain.
       If [crl] is provided, the corresponding file is read and used as
       revocation list (DER encoded). Both options only apply if [`CAs] is used.
  *)

--- a/opam
+++ b/opam
@@ -30,7 +30,7 @@ depends: [
   "cstruct-sexp"
   "sexplib"
   "nocrypto" {>= "0.5.4"}
-  "x509" {>= "0.7.0"}
+  "x509" {>= "0.9.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"
   "cstruct-unix" {with-test & >= "3.0.0"}

--- a/opam
+++ b/opam
@@ -19,7 +19,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.05.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}


### PR DESCRIPTION
addresses some points of #399 and adapts to the new x509 API. on top of #403