### PR TITLE
tls.lwt uses nocrypto.lwt (to seed the RNG), record this dependency in _tags

### DIFF
--- a/_tags
+++ b/_tags
@@ -15,7 +15,7 @@ true : package(cstruct cstruct-sexp nocrypto x509 sexplib domain-name fmt)
 
 <tests/*> : package(oUnit cstruct-unix)
 
-<lwt/**/*> : package(lwt lwt.unix ptime.clock.os)
+<lwt/**/*> : package(lwt lwt.unix ptime.clock.os nocrypto.lwt)
 <lwt> : include
 <lwt/examples/*> : package(nocrypto.lwt), thread
 


### PR DESCRIPTION
I'm not sure how this could've ever worked (the META for the lwt subpackage already contains the nocrypto.lwt dependency).