### PR TITLE
Demote group/cipher logging to DEBUG

### DIFF
--- a/lib/handshake_server13.ml
+++ b/lib/handshake_server13.ml
@@ -90,8 +90,8 @@ let answer_client_hello ~hrr state ch raw =
                    | Some _ -> [`Record change_cipher_spec]))
       end
   | Some group, Some cipher ->
-    Log.info (fun m -> m "cipher %a" Sexplib.Sexp.pp_hum (Ciphersuite.sexp_of_ciphersuite13 cipher)) ;
-    Log.info (fun m -> m "group %a" Sexplib.Sexp.pp_hum (Core.sexp_of_group group)) ;
+    Log.debug (fun m -> m "cipher %a" Sexplib.Sexp.pp_hum (Ciphersuite.sexp_of_ciphersuite13 cipher)) ;
+    Log.debug (fun m -> m "group %a" Sexplib.Sexp.pp_hum (Core.sexp_of_group group)) ;
 
     match List.mem group groups, keyshare group with
     | false, _ | _, None -> fail (`Fatal `NoSupportedGroup) (* TODO: better error type? *)


### PR DESCRIPTION
When using `logs` through a parent application like `opium`, cipher and group information would appear for every new connection established. When log level is set to info, 95% of the logs would be about cipher and group. It seems a good idea to restrict the scope of this information to `debug`.