### PR TITLE
Add http2 ciphersuite list

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -109,6 +109,21 @@ module Ciphers = struct
     `RSA_WITH_3DES_EDE_CBC_SHA ;
     ]
 
+  let http2 = [
+    `AES_128_GCM_SHA256 ;
+    `AES_256_GCM_SHA384 ;
+    `CHACHA20_POLY1305_SHA256 ;
+    `AES_128_CCM_SHA256 ;
+    `DHE_RSA_WITH_AES_256_GCM_SHA384 ;
+    `DHE_RSA_WITH_AES_128_GCM_SHA256 ;
+    `DHE_RSA_WITH_AES_256_CCM ;
+    `DHE_RSA_WITH_AES_128_CCM ;
+    `DHE_RSA_WITH_CHACHA20_POLY1305_SHA256 ;
+    `ECDHE_RSA_WITH_AES_128_GCM_SHA256 ;
+    `ECDHE_RSA_WITH_AES_256_GCM_SHA384 ;
+    `ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 ;
+  ]
+
   let fs_of = List.filter Ciphersuite.ciphersuite_fs
 
   let fs = fs_of default

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -155,6 +155,11 @@ module Ciphers : sig
   (** [fs] is a list of ciphersuites which provide forward secrecy
       (sublist of [default]). *)
 
+  val http2 : ciphersuite list
+  (** [http2] is a list of ciphersuites available that do not appear in the {{:
+    https://httpwg.org/specs/rfc7540.html#BadCipherSuites } http2 blacklist}
+    (sublist of [default]) *)
+
   val fs_of : ciphersuite list -> ciphersuite list
   (** [fs_of ciphers] selects all ciphersuites which provide forward
       secrecy from [ciphers]. *)


### PR DESCRIPTION
This adds a convenience value for the list of http2 suites that do not appear on the blacklist.

As mentioned in [here](https://discuss.ocaml.org/t/strange-prohibited-tls-1-2-cipher-suite-9d-issue/6904/4)