### PR TITLE
Improve ECC support in TLS 1.2 (RFC 8422)

### DIFF
--- a/lib/core.ml
+++ b/lib/core.ml
@@ -213,6 +213,7 @@ type client_extension = [
   | `PostHandshakeAuthentication
   | `Cookie of Cstruct_sexp.t
   | `PskKeyExchangeModes of psk_key_exchange_mode list
+  | `ECPointFormats
   | `UnknownExtension of (int * Cstruct_sexp.t)
 ] [@@deriving sexp]
 
@@ -229,6 +230,7 @@ type server_extension = [
   | `SecureRenegotiation of Cstruct_sexp.t
   | `ExtendedMasterSecret
   | `ALPN of string
+  | `ECPointFormats
   | `UnknownExtension of (int * Cstruct_sexp.t)
 ] [@@deriving sexp]
 

--- a/lib/handshake_client.ml
+++ b/lib/handshake_client.ml
@@ -19,7 +19,7 @@ let default_client_hello config =
   let version = max_protocol_version config.protocol_versions in
   let ecc_groups = match List.filter Config.elliptic_curve config.groups with
     | [] -> []
-    | xs -> [ `SupportedGroups (List.map group_to_named_group xs) ]
+    | xs -> [ `ECPointFormats ; `SupportedGroups (List.map group_to_named_group xs) ]
   in
   let extensions, secrets = match version with
     | `TLS_1_0 | `TLS_1_1 -> (ecc_groups, [])
@@ -44,8 +44,14 @@ let default_client_hello config =
       in
       let all = all_versions config.protocol_versions in
       let supported_versions = List.map (fun x -> (x :> tls_any_version)) all in
+      let point_format =
+        if min_protocol_version config.protocol_versions = `TLS_1_3 then
+          []
+        else
+          [ `ECPointFormats ]
+      in
       let exts =
-        [`SignatureAlgorithms sig_alg ; `SupportedGroups groups ; `KeyShare keyshares ; `SupportedVersions supported_versions ]
+        point_format @ [`SignatureAlgorithms sig_alg ; `SupportedGroups groups ; `KeyShare keyshares ; `SupportedVersions supported_versions ]
       in
       (exts, secrets)
   in

--- a/lib/handshake_common.ml
+++ b/lib/handshake_common.ml
@@ -170,7 +170,7 @@ let to_client_ext_type = function
   | `Hostname _            -> `Hostname
   | `MaxFragmentLength _   -> `MaxFragmentLength
   | `SupportedGroups _     -> `SupportedGroups
-  | `ECPointFormats _      -> `ECPointFormats
+  | `ECPointFormats        -> `ECPointFormats
   | `SecureRenegotiation _ -> `SecureRenegotiation
   | `Padding _             -> `Padding
   | `SignatureAlgorithms _ -> `SignatureAlgorithms
@@ -189,7 +189,7 @@ let to_client_ext_type = function
 let to_server_ext_type = function
   | `Hostname              -> `Hostname
   | `MaxFragmentLength _   -> `MaxFragmentLength
-  | `ECPointFormats _      -> `ECPointFormats
+  | `ECPointFormats        -> `ECPointFormats
   | `SecureRenegotiation _ -> `SecureRenegotiation
   | `UnknownExtension _    -> `UnknownExtension
   | `ExtendedMasterSecret  -> `ExtendedMasterSecret

--- a/lib/writer.ml
+++ b/lib/writer.ml
@@ -181,6 +181,11 @@ let assemble_extension = function
      set_uint8 buf 0 (len x);
      (buf <+> x, RENEGOTIATION_INFO)
   | `ExtendedMasterSecret -> (create 0, EXTENDED_MASTER_SECRET)
+  | `ECPointFormats ->
+    (* a list of point formats, we support type 0 = uncompressed unconditionally *)
+    let data = Cstruct.create 2 in
+    Cstruct.set_uint8 data 0 1;
+    (data, EC_POINT_FORMATS)
   | _ -> invalid_arg "unknown extension"
 
 let assemble_cookie c =


### PR DESCRIPTION
The Go implementation of TLS dislikes client hello without a ECPointFormats
extension, so let's revert from #413 and re-add this extension with a single
value (uncompressed) to client hello (and server hello if client sent it, and
an ECC ciphersuite was selected).

In TLS 1.3 only settings, this change is a no-op.