### PR TITLE
Use sexp_of ppx and remove unnecessary t_of_sexp stubs

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -6,28 +6,25 @@ open Sexplib.Std
 let src = Logs.Src.create "tls.config" ~doc:"TLS config"
 module Log = (val Logs.src_log src : Logs.LOG)
 
-type certchain = Cert.t list * Priv.t [@@deriving sexp]
+type certchain = Cert.t list * Priv.t [@@deriving sexp_of]
 
 type own_cert = [
   | `None
   | `Single of certchain
   | `Multiple of certchain list
   | `Multiple_default of certchain * certchain list
-] [@@deriving sexp]
+] [@@deriving sexp_of]
 
 type session_cache = SessionID.t -> epoch_data option
-let session_cache_of_sexp _ = fun _ -> None
 let sexp_of_session_cache _ = Sexplib.Sexp.Atom "SESSION_CACHE"
 
 module Auth = struct
   type t = X509.Authenticator.t
-  let t_of_sexp _ = failwith "can't convert sexp to authenticator"
   let sexp_of_t _ = Sexplib.Sexp.Atom "Authenticator"
 end
 
 module DN = struct
   type t = X509.Distinguished_name.t
-  let t_of_sexp _ = failwith "can't convert sexp to distinguished name"
   let sexp_of_t _ = Sexplib.Sexp.Atom "distinguished name"
 end
 
@@ -39,7 +36,6 @@ type ticket_cache = {
 }
 
 type ticket_cache_opt = ticket_cache option
-let ticket_cache_opt_of_sexp _ = None
 let sexp_of_ticket_cache_opt _ = Sexplib.Sexp.Atom "TICKET_CACHE"
 
 (* TODO: min_rsa, min_dh *)
@@ -59,7 +55,7 @@ type config = {
   alpn_protocols : string list ;
   groups : group list ;
   zero_rtt : int32 ;
-} [@@deriving sexp]
+} [@@deriving sexp_of]
 
 let ciphers13 cfg =
   List.rev
@@ -494,8 +490,8 @@ let validate_server config =
     | _ -> () );
   { config with ciphers ; signature_algorithms }
 
-type client = config [@@deriving sexp]
-type server = config [@@deriving sexp]
+type client = config [@@deriving sexp_of]
+type server = config [@@deriving sexp_of]
 
 let of_server conf = conf
 and of_client conf = conf

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -43,25 +43,16 @@ type config = private {
   alpn_protocols : string list ; (** optional ordered list of accepted alpn_protocols *)
   groups : group list ; (** the first FFDHE will be used for TLS 1.2 and below if a DHE ciphersuite is used *)
   zero_rtt : int32 ;
-}
-
-val config_of_sexp : Sexplib.Sexp.t -> config
-val sexp_of_config : config -> Sexplib.Sexp.t
+} [@@deriving sexp_of]
 
 (** [ciphers13 config] are the ciphersuites for TLS 1.3 in the configuration. *)
 val ciphers13 : config -> Ciphersuite.ciphersuite13 list
 
 (** opaque type of a client configuration *)
-type client
-
-val client_of_sexp : Sexplib.Sexp.t -> client
-val sexp_of_client : client -> Sexplib.Sexp.t
+type client [@@deriving sexp_of]
 
 (** opaque type of a server configuration *)
-type server
-
-val server_of_sexp : Sexplib.Sexp.t -> server
-val sexp_of_server : server -> Sexplib.Sexp.t
+type server [@@deriving sexp_of]
 
 (** {1 Constructors} *)
 

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -371,7 +371,6 @@ type master_secret = Cstruct_sexp.t [@@deriving sexp]
 
 module Cert = struct
   include X509.Certificate
-  let t_of_sexp _ = failwith "can't convert certificate from S-expression"
   let sexp_of_t _ = Sexplib.Sexp.Atom "certificate"
 end
 
@@ -424,7 +423,7 @@ type epoch_data = {
   session_id             : SessionID.t ;
   extended_ms            : bool ;
   alpn_protocol          : string option ;
-} [@@deriving sexp]
+} [@@deriving sexp_of]
 
 let supports_key_usage ?(not_present = false) usage cert =
   match X509.Extension.(find Key_usage (X509.Certificate.extensions cert)) with

--- a/lib/engine.ml
+++ b/lib/engine.ml
@@ -10,7 +10,7 @@ type state = State.state
 type client_hello_errors = State.client_hello_errors
 type error = State.error
 type fatal = State.fatal
-type failure = State.failure [@@deriving sexp]
+type failure = State.failure [@@deriving sexp_of]
 
 let alert_of_authentication_failure = function
   | `LeafCertificateExpired _ -> Packet.CERTIFICATE_EXPIRED
@@ -748,7 +748,7 @@ let server config = new_state Config.(of_server config) `Server
 type epoch = [
   | `InitialEpoch
   | `Epoch of epoch_data
-] [@@deriving sexp]
+] [@@deriving sexp_of]
 
 let epoch state =
   match epoch_of_hs state.handshake with

--- a/lib/engine.mli
+++ b/lib/engine.mli
@@ -129,19 +129,13 @@ type fatal = [
 type failure = [
   | `Error of error
   | `Fatal of fatal
-]
+] [@@deriving sexp_of]
 
 (** [alert_of_failure failure] is [alert], the TLS alert type for this failure. *)
 val alert_of_failure : failure -> Packet.alert_type
 
 (** [string_of_failure failure] is [string], the string representation of the [failure]. *)
 val string_of_failure : failure -> string
-
-(** [failure_of_sexp sexp] is [failure], the unmarshalled [sexp]. *)
-val failure_of_sexp : Sexplib.Sexp.t -> failure
-
-(** [sexp_of_failure failure] is [sexp], the marshalled [failure]. *)
-val sexp_of_failure : failure -> Sexplib.Sexp.t
 
 (** {1 Protocol handling} *)
 
@@ -200,13 +194,7 @@ val key_update : ?request:bool -> state -> (state * Cstruct.t, failure) result
 type epoch = [
   | `InitialEpoch
   | `Epoch of Core.epoch_data
-]
-
-(** [epoch_of_sexp sexp] is [epoch], the unmarshalled [sexp]. *)
-val epoch_of_sexp : Sexplib.Sexp.t -> epoch
-
-(** [sexp_of_epoch epoch] is [sexp], the marshalled [epoch]. *)
-val sexp_of_epoch : epoch -> Sexplib.Sexp.t
+] [@@deriving sexp_of]
 
 (** [epoch state] is [epoch], which contains the session
     information. *)

--- a/lib/reader.mli
+++ b/lib/reader.mli
@@ -6,10 +6,7 @@ type error =
   | Underflow
   | Overflow       of int
   | UnknownVersion of (int * int)
-  | UnknownContent of int
-
-val error_of_sexp : Sexplib.Sexp.t -> error
-val sexp_of_error : error -> Sexplib.Sexp.t
+  | UnknownContent of int [@@deriving sexp]
 
 val parse_version     : Cstruct.t -> (Core.tls_version, error) result
 val parse_any_version : Cstruct.t -> (Core.tls_any_version, error) result

--- a/lib/reader.mli
+++ b/lib/reader.mli
@@ -6,7 +6,7 @@ type error =
   | Underflow
   | Overflow       of int
   | UnknownVersion of (int * int)
-  | UnknownContent of int [@@deriving sexp]
+  | UnknownContent of int [@@deriving sexp_of]
 
 val parse_version     : Cstruct.t -> (Core.tls_version, error) result
 val parse_any_version : Cstruct.t -> (Core.tls_any_version, error) result

--- a/lib/state.ml
+++ b/lib/state.ml
@@ -249,7 +249,7 @@ type client_hello_errors = [
   | `NotSubsetKeyShareSupportedGroup of (Packet.named_group list * (Packet.named_group * Cstruct_sexp.t) list)
   | `Has0rttAfterHRR
   | `NoCookie
-] [@@deriving sexp]
+] [@@deriving sexp_of]
 
 type fatal = [
   | `NoSecureRenegotiation
@@ -294,7 +294,7 @@ type fatal = [
   | `MissingContentType
   | `Downgrade12
   | `Downgrade11
-] [@@deriving sexp]
+] [@@deriving sexp_of]
 
 type failure = [
   | `Error of error


### PR DESCRIPTION
[@@deriving sexp_of] seems like the more appropriate ppx to use given many of the types in lib/ can't be deserialized.

This would avoid confusion like https://github.com/mirleft/ocaml-tls/pull/398 where it's unclear if a state can be restored from an S-expression.