### PR TITLE
Drop dependency on Async_find

### DIFF
--- a/async/dune
+++ b/async/dune
@@ -2,4 +2,4 @@
   (name        tls_async)
   (public_name tls-async)
   (preprocess (pps ppx_jane))
-  (libraries async async_find core cstruct-async mirage-crypto-rng-async tls))
+  (libraries async core cstruct-async mirage-crypto-rng-async tls))

--- a/async/x509_async.ml
+++ b/async/x509_async.ml
@@ -8,10 +8,9 @@ let file_contents file =
 
 let load_all_in_directory ~directory ~f =
   let open Deferred.Or_error.Let_syntax in
-  let options = Async_find.Options.ignore_errors in
-  let%bind files = Async_find.find_all ~options directory |> Deferred.ok in
-  Deferred.Or_error.List.map files ~f:(fun (file, (_ : Unix.Stats.t)) ->
-    let%bind contents = file_contents file in
+  let%bind files = Deferred.Or_error.try_with (fun () -> Sys.ls_dir directory) in
+  Deferred.Or_error.List.map files ~f:(fun file ->
+    let%bind contents = file_contents (directory ^/ file) in
     f ~contents)
 ;;
 

--- a/tls-async.opam
+++ b/tls-async.opam
@@ -20,7 +20,6 @@ depends: [
   "x509" {>= "0.14.0"}
   "ptime" {>= "0.8.1"}
   "async" {>= "v0.14"}
-  "async_find" {>= "v0.14"}
   "async_unix" {>= "v0.14"}
   "core" {>= "v0.14"}
   "cstruct-async"


### PR DESCRIPTION
I propose we remove the single invocation of [Async_find] in [X509_async] to drop the dependency.

This also has the nice property of truing up the Async version with the existing Lwt version by dropping support for nested directory structures.