### PR TITLE
Add homepage in dune-project

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -2,3 +2,4 @@
 (name tls)
 (formatting disabled)
 (using mdx 0.2)
+(homepage https://github.com/mirleft/ocaml-tls)


### PR DESCRIPTION
This is needed if you want to install a pinned version using opam. Otherwise it fails with:

    # File "lib/engine.mli", line 34, characters 24-40:
    # 34 |     {e %%VERSION%% - {{:%%PKG_HOMEPAGE%% }homepage}} *)
    #                              ^^^^^^^^^^^^^^^^
    # Error: variable "homepage" not found in dune-project file