### PR TITLE
tls-eio: Fix end-of-file handling

### DIFF
--- a/eio/tls_eio.ml
+++ b/eio/tls_eio.ml
@@ -47,7 +47,7 @@ module Raw = struct
       | Ok (state', `Response resp, `Data data) ->
           let state' = match state' with
             | `Ok tls  -> `Active tls
-            | `Eof     -> raise End_of_file
+            | `Eof     -> `Eof
             | `Alert a -> `Error (Tls_alert a)
           in
           t.state <- state' ;

--- a/eio/x509_eio.ml
+++ b/eio/x509_eio.ml
@@ -50,7 +50,7 @@ let certs_of_pem path =
 let certs_of_pem_dir path =
   Path.read_dir path
   |> List.filter (fun file -> extension file = Some "crt")
-  |> Eio.Fiber.map (fun file -> certs_of_pem (path </> file))
+  |> Fiber.List.map (fun file -> certs_of_pem (path </> file))
   |> List.concat
 
 let crl_of_pem path =
@@ -64,7 +64,7 @@ let crl_of_pem path =
 
 let crls_of_pem_dir path =
   Path.read_dir path
-  |> Fiber.map (fun file -> crl_of_pem (path </> file))
+  |> Fiber.List.map (fun file -> crl_of_pem (path </> file))
 
 (* Would be better to take an Eio.Time.clock here, but that API is likely to change soon. *)
 let authenticator ?allowed_hashes ?crls param =

--- a/tls-eio.opam
+++ b/tls-eio.opam
@@ -20,8 +20,8 @@ depends: [
   "mirage-crypto-rng" {>= "0.8.0"}
   "mirage-crypto-rng-eio" {>= "0.8.0" with-test}
   "x509" {>= "0.15.0"}
-  "eio" {>= "0.5"}
-  "eio_main" {>= "0.5" with-test}
+  "eio" {>= "0.6"}
+  "eio_main" {>= "0.6" with-test}
   "mdx" {with-test}
 ]
 tags: [ "org:mirage"]


### PR DESCRIPTION
I introduced this bug in f32809976cdf03c19ade77 (not in the history due to squash merge). However, setting the state to `Eof` is not the same as reporting end-of-file to the user, and we may still have data to report. This can cause us to miss data at the end of the stream in some cases.