### PR TITLE
tls-eio: allow cancelling reads

### DIFF
--- a/eio/tests/dune
+++ b/eio/tests/dune
@@ -14,7 +14,7 @@
 
 ; "dune runtest" just does a quick run with random inputs.
 ;
-; To run with afl-fuzz instead:
+; To run with afl-fuzz instead (make sure you have a compiler with the afl option on!):
 ;
 ; dune runtest
 ; mkdir input

--- a/eio/tests/fuzz.ml
+++ b/eio/tests/fuzz.ml
@@ -148,10 +148,12 @@ end = struct
       | `Send len ->
         let available = String.length t.message - t.sent in
         let len = min len available in
-        let msg = Cstruct.of_string ~off:t.sent ~len t.message in
-        t.sent <- t.sent + len;
-        Log.info (fun f -> f "%a: sending %S" pp_dir t (Cstruct.to_string msg));
-        Eio.Flow.write sender [msg];
+        if len > 0 then (
+          let msg = Cstruct.of_string ~off:t.sent ~len t.message in
+          t.sent <- t.sent + len;
+          Log.info (fun f -> f "%a: sending %S" pp_dir t (Cstruct.to_string msg));
+          Eio.Flow.write sender [msg];
+        );
         aux ()
     in
     aux()
@@ -253,7 +255,27 @@ let dispatch_commands ~to_server ~to_client actions =
   in
   aux actions
 
-let main client_message server_message actions =
+(* In some runs we automatically perform these actions first, which allows the handshake to complete.
+   This lets the fuzz tester get to the interesting cases more quickly. *)
+let quickstart_actions = [
+  Some (To_server, Transmit (`Bytes 4096));
+  None; (* Client sends handshake *)
+  None; (* Server reads handshake *)
+  Some (To_client, Transmit (`Bytes 4096));
+  None; (* Server replies to handshake *)
+  None; (* Client reads reply *)
+  Some (To_server, Transmit (`Bytes 4096));
+  None; (* Client sends final part *)
+  None; (* Server receives it *)
+  Some (To_client, Recv);
+  Some (To_server, Recv);
+]
+
+let main client_message server_message quickstart actions =
+  let actions =
+    if quickstart then quickstart_actions @ actions
+    else actions
+  in
   Eio_mock.Backend.run @@ fun () ->
   Switch.run @@ fun sw ->
   let insecure_test_rng = Mirage_crypto_rng.create (module Test_rng) in
@@ -287,13 +309,17 @@ let main client_message server_message actions =
   ]
 
 let () =
-  Crowbar.(add_test ~name:"random ops" [bytes; bytes; list action] main)
-(*
-  Logs.(set_level (Some Info));
-  Logs.set_reporter (Logs_fmt.reporter ());
-  ignore action;
-  main "ping" "pong" [
-    Some (To_server, Send 5);
-    Some (To_client, Send 5);
-  ]
-*)
+  if true then
+    Crowbar.(add_test ~name:"random ops" [bytes; bytes; bool; list action] main)
+  else (
+    Logs.(set_level (Some Info));
+    Logs.set_reporter (Logs_fmt.reporter ());
+    main "ping" "pong" true [
+      Some (To_server, Send 4);
+      Some (To_server, Transmit (`Bytes 4096));
+      None;
+      Some (To_client, Send 4);
+      Some (To_client, Transmit (`Bytes 4096));
+      None;
+    ]
+  )

--- a/eio/tls_eio.ml
+++ b/eio/tls_eio.ml
@@ -29,7 +29,7 @@ module Raw = struct
       raise exn
 
   let write_t t cs =
-    try Flow.copy (Flow.cstruct_source [cs]) t.flow
+    try Flow.write t.flow [cs]
     with exn ->
       (match t.state with
        | `Error _ | `Eof -> ()

--- a/eio/tls_eio.ml
+++ b/eio/tls_eio.ml
@@ -22,6 +22,9 @@ module Raw = struct
     | End_of_file as ex ->
       t.state <- `Eof;
       raise ex
+    | Eio.Cancel.Cancelled _ as ex ->
+      (* No need to break the flow just because a read got cancelled. *)
+      raise ex
     | exn ->
       (match t.state with
        | `Error _ | `Eof -> ()


### PR DESCRIPTION
Previously, Tls would treat any exception from a read as a permanent error, causing all future operations to fail. However, it is reasonable to cancel a read and then try again later. I extended the fuzz tests to check for this case.

Note that the Lwt version appears to have the same problem. Possibly we should only be catching `Eio.Io` exceptions in the first place, or maybe none at all.

The first commit cleans up the fuzz testing a bit (see the commit comment for details) and the second one adds support for cancellation.

One place I'm not sure about is when `drain_handshake` is called from `reneg`. Is it OK to abort there? I don't know what the function does and it's already marked with `XXX`. In the normal case (when `drain_handshake` is called during flow creation) it's safe because the caller never gets the `Tls_eio.t`.

I'm not sure whether we really want to encourage users to cancel reads and resume later, but this should at least fix the confusing `Cancelled: Eio__core__Fiber.Not_first` errors reported by @bikallem in #458.