### PR TITLE
tls-eio: fix shutdown semantics of tls_eio flow

### DIFF
--- a/eio/tls_eio.ml
+++ b/eio/tls_eio.ml
@@ -155,9 +155,11 @@ module Raw = struct
   (* Not sure if we need to keep both directions open on the underlying flow when closing
      one direction at the TLS level. *)
   let shutdown t = function
-    | `Send -> close_tls t
+    | `Send -> close_tls t ; Flow.shutdown t.flow `Send
     | `All -> close_tls t; Flow.shutdown t.flow `All
-    | `Receive -> ()  (* Not obvious how to do this with TLS, so ignore for now. *)
+    | `Receive ->
+        (* XXX talex Not obvious how to do this with TLS, so ignore for now. *)
+        Flow.shutdown t.flow `Receive
 
   let server_of_flow config flow =
     drain_handshake {


### PR DESCRIPTION
This PR makes `tls_eio` flow instance follow shutdown semantics as specified by `eio` - https://github.com/ocaml-multicore/eio/blob/main/lib_eio/flow.mli#L92-L95)

The rationale for this change is that in addition to following tls semantics, tls-eio has to follow at the minimum flow semantics as espoused by `eio`. 

/cc @talex5 @hannesm 

EDIT The test fails on current `tls-eio` but passes with this PR.