### PR TITLE
tls-eio: improve fuzz tests

### DIFF
--- a/eio/tests/dune
+++ b/eio/tests/dune
@@ -14,7 +14,7 @@
 
 ; "dune runtest" just does a quick run with random inputs.
 ;
-; To run with afl-fuzz instead:
+; To run with afl-fuzz instead (make sure you have a compiler with the afl option on!):
 ;
 ; dune runtest
 ; mkdir input


### PR DESCRIPTION
These are the improvements to the fuzz tests that were part of #459. I think it's worth merging these on their own, since that PR isn't ready.

- The mock_socket has changed slightly. Previously, it would request a size to read, do the read, and then wait for another size for the next read, which would typically just be the EOF for that request. This made it harder for the fuzzer to reach useful states. Now you can do a single transmit with a single test action.

- ~Simplified the write in Tls_eio slightly by using the new `Flow.write` operation.~

- Only log a send when we actually send some data.

- Allow the fuzzer to perform all the actions needed for the Tls handshake in one go instead of requiring it to find them by searching. This provides it a way to get to the interesting cases quickly.