### PR TITLE
Option allow_ca_cert for buggy server certificates where CA=true

### DIFF
--- a/async/x509_async.mli
+++ b/async/x509_async.mli
@@ -16,6 +16,7 @@ module Authenticator : sig
     val ca_file
       :  ?allowed_hashes:Mirage_crypto.Hash.hash list
       -> ?crls:Filename.t
+      -> ?allow_ca_cert:bool
       -> Filename.t
       -> unit
       -> t
@@ -23,6 +24,7 @@ module Authenticator : sig
     val ca_dir
       :  ?allowed_hashes:Mirage_crypto.Hash.hash list
       -> ?crls:Filename.t
+      -> ?allow_ca_cert:bool
       -> Filename.t
       -> unit
       -> t


### PR DESCRIPTION
Discussed previously in #446. This allows connecting to TLS endpoints that have set the CA=true flag on their server certificates. OpenSSL and other TLS libraries not based on OpenSSL allow this, so this is unfortunately a necessary evil.

As suggested by @hannesm, it's disabled by default and will print a warning if it comes up.

Usage is to simply create an authenticator with this parameter:

```ocaml
Authenticator.Param.ca_file ?crls ?allowed_hashes ~allow_ca_cert:true ca_file ()
```

This depends on the companion PR in https://github.com/mirleft/ocaml-x509/pull/160 
