### PR TITLE
Mirage crypto.0.11.0

### DIFF
--- a/lib/state.ml
+++ b/lib/state.ml
@@ -27,7 +27,7 @@ type 'k cbc_state = {
 type nonce = Cstruct.t
 
 type 'k aead_cipher =
-  | CCM of (module Cipher_block.S.CCM with type key = 'k)
+  | CCM16 of (module Cipher_block.S.CCM16 with type key = 'k)
   | GCM of (module Cipher_block.S.GCM with type key = 'k)
   | ChaCha20_Poly1305 of (module AEAD with type key = 'k)
 

--- a/lwt/dune
+++ b/lwt/dune
@@ -2,4 +2,4 @@
  (name tls_lwt)
  (public_name tls.lwt)
  (wrapped false)
- (libraries tls lwt lwt.unix ptime.clock.os mirage-crypto-rng.lwt))
+ (libraries tls lwt lwt.unix ptime.clock.os mirage-crypto-rng-lwt))

--- a/lwt/tls_lwt.ml
+++ b/lwt/tls_lwt.ml
@@ -276,7 +276,7 @@ and connect authenticator addr =
   in connect_ext config addr
 
 (* Boot the entropy loop at module init time. *)
-let () = Mirage_crypto_rng_lwt.initialize ()
+let () = Mirage_crypto_rng_lwt.initialize (module Mirage_crypto_rng.Fortuna)
 
 let () =
   Printexc.register_printer (function

--- a/tests/key_derivation.ml
+++ b/tests/key_derivation.ml
@@ -680,5 +680,5 @@ let () =
   Fmt_tty.setup_std_outputs ();
   Logs.set_level (Some Logs.Debug);
   Logs.set_reporter (Logs_fmt.reporter ~dst:Format.std_formatter ()) ;
-  Mirage_crypto_rng_unix.initialize () ;
+  Mirage_crypto_rng_unix.initialize (module Mirage_crypto_rng.Fortuna) ;
   Alcotest.run "Key derivation tests" [ "key extraction and derivation", tests ]

--- a/tests/testlib.ml
+++ b/tests/testlib.ml
@@ -1,6 +1,6 @@
 open OUnit2
 
-let () = Mirage_crypto_rng_unix.initialize ()
+let () = Mirage_crypto_rng_unix.initialize (module Mirage_crypto_rng.Fortuna)
 
 let time f =
   let t1 = Sys.time () in

--- a/tls.opam
+++ b/tls.opam
@@ -21,10 +21,11 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "cstruct-sexp"
   "sexplib"
-  "mirage-crypto" {>= "0.8.1"}
+  "mirage-crypto" {>= "0.11.0"}
   "mirage-crypto-ec" {>= "0.10.0"}
   "mirage-crypto-pk"
-  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.11.0"}
+  "mirage-crypto-rng-lwt" {>= "0.11.0"}
   "x509" {>= "0.15.0"}
   "domain-name" {>= "0.3.0"}
   "fmt" {>= "0.8.7"}


### PR DESCRIPTION
A simple upgrade to `mirage-crypto.0.11.0`. I did not split `tls` and `tls.lwt` (as you do about `mirage-crypto`) and I think it's needed now - I would like to discuss about that with you first.