### PR TITLE
Upgrade JaneStreet async and core to v.0.16

### DIFF
--- a/async/tls_async.mli
+++ b/async/tls_async.mli
@@ -55,4 +55,4 @@ val connect
       -> 'addr Tcp.Where_to_connect.t
       -> host:[ `host ] Domain_name.t option
       -> (Session.t * Reader.t * Writer.t) Deferred.Or_error.t)
-       Tcp.with_connect_options
+       Tcp.Aliases.with_connect_options

--- a/async/x509_async.ml
+++ b/async/x509_async.ml
@@ -9,7 +9,7 @@ let file_contents file =
 let load_all_in_directory ~directory ~f =
   let open Deferred.Or_error.Let_syntax in
   let%bind files = Deferred.Or_error.try_with (fun () -> Sys.ls_dir directory) in
-  Deferred.Or_error.List.map files ~f:(fun file ->
+  Deferred.Or_error.List.map ~how:`Sequential files ~f:(fun file ->
     let%bind contents = file_contents (directory ^/ file) in
     f ~contents)
 ;;

--- a/tls-async.opam
+++ b/tls-async.opam
@@ -19,11 +19,11 @@ depends: [
   "tls" {= version}
   "x509" {>= "0.14.0"}
   "ptime" {>= "0.8.1"}
-  "async" {>= "v0.16"}
-  "async_unix" {>= "v0.16"}
-  "core" {>= "v0.16"}
+  "async" {>= "v0.16.0"}
+  "async_unix" {>= "v0.16.0"}
+  "core" {>= "v0.16.1"}
   "cstruct-async"
-  "ppx_jane" {>= "v0.16"}
+  "ppx_jane" {>= "v0.16.0"}
   "mirage-crypto-rng-async"
 ]
 tags: [ "org:mirage"]

--- a/tls-async.opam
+++ b/tls-async.opam
@@ -19,11 +19,11 @@ depends: [
   "tls" {= version}
   "x509" {>= "0.14.0"}
   "ptime" {>= "0.8.1"}
-  "async" {>= "v0.15"}
-  "async_unix" {>= "v0.15"}
-  "core" {>= "v0.15"}
+  "async" {>= "v0.16"}
+  "async_unix" {>= "v0.16"}
+  "core" {>= "v0.16"}
   "cstruct-async"
-  "ppx_jane" {>= "v0.15"}
+  "ppx_jane" {>= "v0.16"}
   "mirage-crypto-rng-async"
 ]
 tags: [ "org:mirage"]


### PR DESCRIPTION
Minor fixes to deprecated functions and function interfaces.