### PR TITLE
Update to Eio 0.12

### DIFF
--- a/eio/tests/fuzz.ml
+++ b/eio/tests/fuzz.ml
@@ -296,7 +296,7 @@ let main client_message server_message quickstart actions =
       ~receiver:server_flow
       ~sender_closed:client_closed
       ~receiver_closed:server_closed
-      ~transmit:client_socket#transmit
+      ~transmit:(Mock_socket.transmit client_socket)
       To_server client_message in
   let to_client =
     Path.create
@@ -304,7 +304,7 @@ let main client_message server_message quickstart actions =
       ~receiver:client_flow
       ~sender_closed:server_closed
       ~receiver_closed:client_closed
-      ~transmit:server_socket#transmit
+      ~transmit:(Mock_socket.transmit server_socket)
       To_client server_message
   in
   Fiber.all [

--- a/eio/tests/mock_socket.ml
+++ b/eio/tests/mock_socket.ml
@@ -1,3 +1,5 @@
+open Eio.Std
+
 module W = Eio.Buf_write
 
 let src = Logs.Src.create "mock-socket" ~doc:"Test socket"
@@ -5,48 +7,80 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 type transmit_amount = [`Bytes of int | `Drain]
 
-type socket = < Eio.Flow.two_way; transmit : transmit_amount -> unit >
+type ty = [`Mock_tls | Eio.Flow.two_way_ty]
+type t = ty r
 
-let create ~to_peer ~from_peer label =
-  object
-    inherit Eio.Flow.two_way
+let rec takev len = function
+  | [] -> []
+  | x :: xs ->
+    if len = 0 then []
+    else if Cstruct.length x >= len then [Cstruct.sub x 0 len]
+    else x :: takev (len - Cstruct.length x) xs
 
-    val output_sizes = Eio.Stream.create max_int
+module Impl = struct
+  type t = {
+    to_peer : W.t;
+    from_peer : W.t;
+    label : string;
+    output_sizes : transmit_amount Eio.Stream.t;
+  }
 
-    method transmit x =
-      Eio.Stream.add output_sizes x
+  let create ~to_peer ~from_peer label = {
+    to_peer;
+    from_peer;
+    label;
+    output_sizes = Eio.Stream.create max_int;
+  }
 
-    method copy src =
-      try
-        while true do
-          let rec write = function
-            | 0 -> ()
-            | size ->
-              let buf = Cstruct.create size in
-              let got = Eio.Flow.single_read src buf in
-              W.cstruct to_peer (Cstruct.sub buf 0 got);
-              Log.info (fun f -> f "%s: wrote %d bytes to network" label got);
-              write (size - got)
-          in
-          match Eio.Stream.take output_sizes with
-          | `Drain -> Eio.Stream.add output_sizes `Drain; write 4096
-          | `Bytes n -> write n
-        done
-      with End_of_file -> ()
+  let transmit t x =
+    Eio.Stream.add t.output_sizes x
 
-    method read_into buf =
-      let batch = W.await_batch from_peer in
-      let got, _ = Cstruct.fillv ~src:batch ~dst:buf in
-      Log.info (fun f -> f "%s: read %d bytes from network" label got);
-      W.shift from_peer got;
-      got
+  let single_write t bufs =
+    let size =
+      match Eio.Stream.take t.output_sizes with
+      | `Drain -> Eio.Stream.add t.output_sizes `Drain; Cstruct.lenv bufs
+      | `Bytes size -> size
+    in
+    let bufs = takev size bufs in
+    List.iter (W.cstruct t.to_peer) bufs;
+    let len = Cstruct.lenv bufs in
+    Log.info (fun f -> f "%s: wrote %d bytes to network" t.label len);
+    len
 
-    method shutdown = function
-      | `Send -> 
-        Log.info (fun f -> f "%s: close writer" label);
-        W.close to_peer
-      | _ -> failwith "Not implemented"
-  end
+  let copy t ~src = Eio.Flow.Pi.simple_copy ~single_write t ~src
+
+  let single_read t buf =
+    let batch = W.await_batch t.from_peer in
+    let got, _ = Cstruct.fillv ~src:batch ~dst:buf in
+    Log.info (fun f -> f "%s: read %d bytes from network" t.label got);
+    W.shift t.from_peer got;
+    got
+
+  let shutdown t = function
+    | `Send -> 
+      Log.info (fun f -> f "%s: close writer" t.label);
+      W.close t.to_peer
+    | _ -> failwith "Not implemented"
+
+  let read_methods = []
+
+  type (_, _, _) Eio.Resource.pi += Raw : ('t, 't -> t, ty) Eio.Resource.pi
+  let raw (Eio.Resource.T (t, ops)) = Eio.Resource.get ops Raw t
+end
+
+let handler =
+  Eio.Resource.handler (
+    H (Impl.Raw, Fun.id) ::
+    Eio.Resource.bindings (Eio.Flow.Pi.two_way (module Impl))
+  )
+
+let transmit t x =
+  let t = Impl.raw t in
+  Impl.transmit t x
+
+let create ~from_peer ~to_peer label =
+  let t = Impl.create ~from_peer ~to_peer label in
+  Eio.Resource.T (t, handler)
 
 let create_pair () =
   let to_a = W.create 100 in

--- a/eio/tests/mock_socket.mli
+++ b/eio/tests/mock_socket.mli
@@ -1,12 +1,13 @@
+open Eio.Std
+
 type transmit_amount = [
   | `Bytes of int   (* Send the next n bytes of data *)
   | `Drain          (* Transmit all data immediately from now on *)
 ]
 
-type socket = <
-  Eio.Flow.two_way;
-  transmit : transmit_amount -> unit;
->
+type t = [`Mock_tls | Eio.Flow.two_way_ty] r
 
-val create_pair : unit -> socket * socket
+val create_pair : unit -> t * t
 (** Create a pair of sockets [client, server], such that writes to one can be read from the other. *)
+
+val transmit : t -> transmit_amount -> unit

--- a/eio/tls_eio.mli
+++ b/eio/tls_eio.mli
@@ -3,13 +3,15 @@
     The pure TLS is state and buffer in, state and buffer out.  This
     module uses Eio for communication over the network. *)
 
+open Eio.Std
+
 (** [Tls_alert] exception received from the other endpoint *)
 exception Tls_alert   of Tls.Packet.alert_type
 
 (** [Tls_failure] exception while processing incoming data *)
 exception Tls_failure of Tls.Engine.failure
 
-type t = private < Eio.Flow.two_way; .. >
+type t = [ `Tls | Eio.Flow.two_way_ty ] r
 
 (** {2 Constructors} *)
 
@@ -19,7 +21,7 @@ type t = private < Eio.Flow.two_way; .. >
     You must ensure a RNG is installed while using TLS, e.g. using [Mirage_crypto_rng_eio].
     Ideally, this would be part of the [server] config so you couldn't forget it,
     but for now you'll get a runtime error if you forget. *)
-val server_of_flow : Tls.Config.server -> #Eio.Flow.two_way -> t
+val server_of_flow : Tls.Config.server -> _ Eio.Flow.two_way -> t
 
 (** [client_of_flow client ~host fd] is [t], after client-side
     TLS handshake of [flow] using [client] configuration and [host].
@@ -27,7 +29,7 @@ val server_of_flow : Tls.Config.server -> #Eio.Flow.two_way -> t
     You must ensure a RNG is installed while using TLS, e.g. using [Mirage_crypto_rng_eio].
     Ideally, this would be part of the [client] config so you couldn't forget it,
     but for now you'll get a runtime error if you forget. *)
-val client_of_flow : Tls.Config.client -> ?host:[ `host ] Domain_name.t -> #Eio.Flow.two_way -> t
+val client_of_flow : Tls.Config.client -> ?host:[ `host ] Domain_name.t -> _ Eio.Flow.two_way -> t
 
 (** {2 Control of TLS features} *)
 

--- a/tls-eio.opam
+++ b/tls-eio.opam
@@ -17,11 +17,11 @@ depends: [
   "ocaml" {>= "5.0.0"}
   "dune" {>= "3.0"}
   "tls" {= version}
-  "mirage-crypto-rng" {>= "0.8.0"}
-  "mirage-crypto-rng-eio" {>= "0.8.0" with-test}
+  "mirage-crypto-rng" {>= "0.11.2"}
+  "mirage-crypto-rng-eio" {>= "0.11.2" with-test}
   "x509" {>= "0.15.0"}
-  "eio" {>= "0.7"}
-  "eio_main" {>= "0.7" with-test}
+  "eio" {>= "0.12"}
+  "eio_main" {>= "0.12" with-test}
   "mdx" {with-test}
   "crowbar" {>= "0.2.1" with-test}
 ]

--- a/tls-eio.opam
+++ b/tls-eio.opam
@@ -24,6 +24,8 @@ depends: [
   "eio_main" {>= "0.12" with-test}
   "mdx" {with-test}
   "crowbar" {>= "0.2.1" with-test}
+  "logs" {>= "0.7.0" with-test}
+  "ptime" {>= "1.0.0"}
 ]
 tags: [ "org:mirage"]
 synopsis: "Transport Layer Security purely in OCaml - Eio"


### PR DESCRIPTION
(note: this looks long, but most of the changes are to the fuzz tests)

The changes to tls-eio.ml are:
- Add new `Tls_socket_closed` error. Writing to a closed connection previously reported end-of-file, which isn't quite right.
- Replace the object types with non-object types.
- Rename `read` to `single_read`, `write` to `single_write`, and `copy_from` to `copy`, to match the Eio 0.12 API.
- `copy` now uses an Eio helper that just calls `single_write`.

This removes all uses of objects from `tls-eio.ml`.