### PR TITLE
Implement Eio.Resource.Close

### DIFF
--- a/eio/tests/mock_socket.mli
+++ b/eio/tests/mock_socket.mli
@@ -5,7 +5,7 @@ type transmit_amount = [
   | `Drain          (* Transmit all data immediately from now on *)
 ]
 
-type t = [`Mock_tls | Eio.Flow.two_way_ty] r
+type t = [`Mock_tls | Eio.Flow.two_way_ty | Eio.Resource.close_ty] r
 
 val create_pair : unit -> t * t
 (** Create a pair of sockets [client, server], such that writes to one can be read from the other. *)

--- a/eio/tests/tls_eio.md
+++ b/eio/tests/tls_eio.md
@@ -47,6 +47,7 @@ let test_client ~net (host, service) =
     let r = Eio.Buf_read.of_flow flow ~max_size:max_int in
     let line = Eio.Buf_read.take 3 r in
     traceln "client <- %s" line;
+    Eio.Resource.close flow;
     traceln "client done."
 ```
 

--- a/eio/tls_eio.ml
+++ b/eio/tls_eio.ml
@@ -19,7 +19,7 @@ module Raw = struct
   (* We could replace [`Eof] with [`Error End_of_file] and then use
      a regular [result] type here. *)
   type t = {
-    flow           : Flow.two_way_ty r;
+    flow           : [Flow.two_way_ty | Eio.Resource.close_ty] r;
     mutable state  : [ `Active of Tls.Engine.state
                      | `Read_closed of Tls.Engine.state
                      | `Write_closed of Tls.Engine.state
@@ -185,7 +185,7 @@ module Raw = struct
   let server_of_flow config flow =
     drain_handshake {
       state    = `Active (Tls.Engine.server config) ;
-      flow     = (flow :> Flow.two_way_ty r) ;
+      flow     = (flow :> [Flow.two_way_ty | Eio.Resource.close_ty] r) ;
       linger   = None ;
       recv_buf = Cstruct.create 4096
     }
@@ -198,7 +198,7 @@ module Raw = struct
     let (tls, init) = Tls.Engine.client config' in
     let t = {
       state    = `Active tls ;
-      flow     = (flow :> Flow.two_way_ty r);
+      flow     = (flow :> [Flow.two_way_ty | Eio.Resource.close_ty] r);
       linger   = None ;
       recv_buf = Cstruct.create 4096
     } in
@@ -215,11 +215,7 @@ module Raw = struct
 
   let read_methods = []
 
-  let close t =
-    let Eio.Resource.T (flow, handler) = t.flow in
-    match Eio.Resource.get_opt handler Eio.Resource.Close with
-    | None -> ()
-    | Some close -> close flow
+  let close t = Eio.Resource.close t.flow
 
   type (_, _, _) Eio.Resource.pi += T : ('t, 't -> t, ty) Eio.Resource.pi
 end

--- a/eio/tls_eio.mli
+++ b/eio/tls_eio.mli
@@ -20,22 +20,20 @@ type t = [ `Tls | Eio.Flow.two_way_ty | Eio.Resource.close_ty ] r
 
     You must ensure a RNG is installed while using TLS, e.g. using [Mirage_crypto_rng_eio].
     Ideally, this would be part of the [server] config so you couldn't forget it,
-    but for now you'll get a runtime error if you forget.
-
-    If [flow] also implements [Eio.Resource.Close], then closing the TLS flow
-    will close the underlying flow. *)
-val server_of_flow : Tls.Config.server -> _ Eio.Flow.two_way -> t
+    but for now you'll get a runtime error if you forget. *)
+val server_of_flow :
+  Tls.Config.server ->
+  [> Eio.Flow.two_way_ty | Eio.Resource.close_ty] r -> t
 
 (** [client_of_flow client ~host fd] is [t], after client-side
     TLS handshake of [flow] using [client] configuration and [host].
 
     You must ensure a RNG is installed while using TLS, e.g. using [Mirage_crypto_rng_eio].
     Ideally, this would be part of the [client] config so you couldn't forget it,
-    but for now you'll get a runtime error if you forget.
-
-    If [flow] also implements [Eio.Resource.Close], then closing the TLS flow
-    will close the underlying flow. *)
-val client_of_flow : Tls.Config.client -> ?host:[ `host ] Domain_name.t -> _ Eio.Flow.two_way -> t
+    but for now you'll get a runtime error if you forget. *)
+val client_of_flow :
+  Tls.Config.client -> ?host:[ `host ] Domain_name.t ->
+  [> Eio.Flow.two_way_ty | Eio.Resource.close_ty] r -> t
 
 (** {2 Control of TLS features} *)
 

--- a/eio/tls_eio.mli
+++ b/eio/tls_eio.mli
@@ -11,7 +11,7 @@ exception Tls_alert   of Tls.Packet.alert_type
 (** [Tls_failure] exception while processing incoming data *)
 exception Tls_failure of Tls.Engine.failure
 
-type t = [ `Tls | Eio.Flow.two_way_ty ] r
+type t = [ `Tls | Eio.Flow.two_way_ty | Eio.Resource.close_ty ] r
 
 (** {2 Constructors} *)
 
@@ -20,7 +20,10 @@ type t = [ `Tls | Eio.Flow.two_way_ty ] r
 
     You must ensure a RNG is installed while using TLS, e.g. using [Mirage_crypto_rng_eio].
     Ideally, this would be part of the [server] config so you couldn't forget it,
-    but for now you'll get a runtime error if you forget. *)
+    but for now you'll get a runtime error if you forget.
+
+    If [flow] also implements [Eio.Resource.Close], then closing the TLS flow
+    will close the underlying flow. *)
 val server_of_flow : Tls.Config.server -> _ Eio.Flow.two_way -> t
 
 (** [client_of_flow client ~host fd] is [t], after client-side
@@ -28,7 +31,10 @@ val server_of_flow : Tls.Config.server -> _ Eio.Flow.two_way -> t
 
     You must ensure a RNG is installed while using TLS, e.g. using [Mirage_crypto_rng_eio].
     Ideally, this would be part of the [client] config so you couldn't forget it,
-    but for now you'll get a runtime error if you forget. *)
+    but for now you'll get a runtime error if you forget.
+
+    If [flow] also implements [Eio.Resource.Close], then closing the TLS flow
+    will close the underlying flow. *)
 val client_of_flow : Tls.Config.client -> ?host:[ `host ] Domain_name.t -> _ Eio.Flow.two_way -> t
 
 (** {2 Control of TLS features} *)


### PR DESCRIPTION
After shutting down the TLS flow, I would like to close the underlying TCP socket.  This is of course handled by the switch, but since I'm using resource pooling, I would like to do this before leaving the scope of the switch.  I could pass around the TCP flow along with the TLS flow, but this breaks the flow-abstraction which is very useful when dealing with TLS.

My proposal here is the the TLS flow implements the close interface but falls back to no-op if the underlying flow does not implement it.  We could consider making close a requirement for the underlying flow, since it should be possible to amend a no-op close operation to an existing flow in the (unlikely?) event that a non-TCP flow is used.

(I made a [hack](https://github.com/paurkedal/ocaml-caqti/commit/6f24b835e311488c0cbfaeb408b6a3e1785ad986#diff-6eb80eeba29d292ce5bfc805b43c086ef5e5650d5bc8d2e51d2e05c2685795dd) around the issue, but I prefer a more proper solution.)
