### PR TITLE
Document why Tls.Engine.send_application_data is None

### DIFF
--- a/lib/engine.mli
+++ b/lib/engine.mli
@@ -163,9 +163,10 @@ val handle_tls           : state -> Cstruct.t -> ret
     is a handshake in progress or scheduled. *)
 val handshake_in_progress : state -> bool
 
-(** [send_application_data tls outs] is [(tls' * out) option] where
+(** [send_application_data tls outs] is [Some (tls', out)] where
     [tls'] is the new tls state, and [out] the cstruct to send over the
-    wire (encrypted [outs]). *)
+    wire (encrypted [outs]) when the TLS session is ready. When the TLS
+    session is not ready it is [None]. *)
 val send_application_data : state -> Cstruct.t list -> (state * Cstruct.t) option
 
 (** [send_close_notify tls] is [tls' * out] where [tls'] is the new


### PR DESCRIPTION
As discussed in https://github.com/robur-coop/miragevpn/pull/234/files/4f553471dc81e03790ead342caba5e50ac05fd71#r1576424941