### PR TITLE
Update upper bounds on mirage-crypo and hkdf

### DIFF
--- a/tls-async.opam
+++ b/tls-async.opam
@@ -24,7 +24,7 @@ depends: [
   "core" {>= "v0.16"}
   "cstruct-async"
   "ppx_jane" {>= "v0.16"}
-  "mirage-crypto-rng-async"
+  "mirage-crypto-rng-async" {< "1.0.0"}
 ]
 tags: [ "org:mirage"]
 synopsis: "Transport Layer Security purely in OCaml, Async layer"

--- a/tls-eio.opam
+++ b/tls-eio.opam
@@ -17,8 +17,8 @@ depends: [
   "ocaml" {>= "5.0.0"}
   "dune" {>= "3.0"}
   "tls" {= version}
-  "mirage-crypto-rng" {>= "0.11.2"}
-  "mirage-crypto-rng-eio" {>= "0.11.2" with-test}
+  "mirage-crypto-rng" {>= "0.11.2" & < "1.0.0"}
+  "mirage-crypto-rng-eio" {with-test & >= "0.11.2" & < "1.0.0"}
   "x509" {>= "0.15.0"}
   "eio" {>= "0.12"}
   "eio_main" {>= "0.12" with-test}

--- a/tls-lwt.opam
+++ b/tls-lwt.opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "3.0"}
   "tls" {= version}
-  "mirage-crypto-rng-lwt" {>= "0.11.0"}
+  "mirage-crypto-rng-lwt" {>= "0.11.0" & < "1.0.0"}
   "x509" {>= "0.15.0"}
   "lwt" {>= "5.7.0"}
   "cmdliner" {>= "1.1.0"}

--- a/tls-mirage.opam
+++ b/tls-mirage.opam
@@ -24,8 +24,8 @@ depends: [
   "mirage-kv" {>= "3.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "ptime" {>= "0.8.1"}
-  "mirage-crypto"
-  "mirage-crypto-pk"
+  "mirage-crypto" {< "1.0.0"}
+  "mirage-crypto-pk" {< "1.0.0"}
 ]
 tags: [ "org:mirage"]
 synopsis: "Transport Layer Security purely in OCaml, MirageOS layer"

--- a/tls.opam
+++ b/tls.opam
@@ -17,16 +17,16 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "3.0"}
   "cstruct" {>= "6.0.0"}
-  "mirage-crypto" {>= "0.11.0"}
-  "mirage-crypto-ec" {>= "0.10.0"}
-  "mirage-crypto-pk"
-  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto" {>= "0.11.0" & < "1.0.0"}
+  "mirage-crypto-ec" {>= "0.10.0" & < "1.0.0"}
+  "mirage-crypto-pk" {< "1.0.0"}
+  "mirage-crypto-rng" {>= "0.8.0" & < "1.0.0"}
   "x509" {>= "0.15.0"}
   "domain-name" {>= "0.3.0"}
   "fmt" {>= "0.8.7"}
   "cstruct-unix" {with-test & >= "3.0.0"}
   "ounit2" {with-test & >= "2.2.0"}
-  "hkdf"
+  "hkdf" {< "2.0.0"}
   "logs"
   "ipaddr"
   "alcotest" {with-test}


### PR DESCRIPTION
- mirage-crypto* < 1.0.0
- hkdf < 2.0.0

The upper-bounds are taken from the opam-repository.