### PR TITLE
TLS over an existing connection

### DIFF
--- a/async/tls_async.mli
+++ b/async/tls_async.mli
@@ -56,3 +56,19 @@ val connect
       -> host:[ `host ] Domain_name.t option
       -> (Session.t * Reader.t * Writer.t) Deferred.Or_error.t)
        Tcp.Aliases.with_connect_options
+
+(** [upgrade_client_to_tls] upgrades an existing reader/writer to TLS,
+    returning a cleartext reader and writer.
+    Callers should ensure they close the [Writer.t] and wait for the [unit Deferred.t]
+    returned by [`Closed_and_flushed_downstream] to completely shut down the TLS connection
+
+    [host] is used for peer name verification and should generally be provided. Passing
+    [None] will disable peer name verification unless [peer_name] was provided in the
+    [Tls.Config.client]. If both are present [host] overwrites [peer_name].
+*)
+val upgrade_client_to_tls
+  :  Tls.Config.client
+  -> host:[ `host ] Domain_name.t option
+  -> Reader.t
+  -> Writer.t
+  -> (Session.t * Reader.t * Writer.t) Deferred.Or_error.t

--- a/lwt/examples/dune
+++ b/lwt/examples/dune
@@ -44,6 +44,11 @@
  (libraries tls-lwt lwt.unix ex_common))
 
 (executable
+ (name tls_over_tls)
+ (modules tls_over_tls)
+ (libraries tls-lwt lwt lwt.unix ex_common))
+
+(executable
  (name http_client)
  (modules http_client)
  (libraries tls-lwt lwt.unix ex_common))

--- a/lwt/examples/tls_over_tls.ml
+++ b/lwt/examples/tls_over_tls.ml
@@ -28,7 +28,7 @@ https_port 3129 tls-cert=/path/to/localhost.crt tls-key=/path/to/localhost.key
 
 *)
 
-let client = Tls.Config.client ~authenticator:null_auth ()
+let client = get_ok (Tls.Config.client ~authenticator:null_auth ())
 
 let string_prefix ~prefix msg =
   let len = String.length prefix in

--- a/lwt/examples/tls_over_tls.ml
+++ b/lwt/examples/tls_over_tls.ml
@@ -1,0 +1,104 @@
+open Lwt
+open Ex_common
+
+let hostname = "mirage.io"
+
+(* To test TLS-over-TLS, the `squid` proxy can be installed locally and configured to support HTTPS:
+
+- Generate a certificate for localhost: https://gist.github.com/cecilemuller/9492b848eb8fe46d462abeb26656c4f8
+
+$ openssl req -x509 -nodes -new -sha256 -days 1024 -newkey rsa:2048 -keyout RootCA.key -out RootCA.pem -subj "/C=US/CN=Example-Root-CA"
+$ openssl x509 -outform pem -in RootCA.pem -out RootCA.crt
+$ cat <<EOF > domains.ext
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = localhost
+EOF
+$ openssl req -new -nodes -newkey rsa:2048 -keyout localhost.key -out localhost.csr -subj "/C=US/ST=YourState/L=YourCity/O=Example-Certificates/CN=localhost.local"
+$ openssl x509 -req -sha256 -days 1024 -in localhost.csr -CA RootCA.pem -CAkey RootCA.key -CAcreateserial -extfile domains.ext -out localhost.crt
+
+- Configure squid by adding HTTPS support on port 3129 in /etc/squid/squid.conf :
+
+https_port 3129 tls-cert=/path/to/localhost.crt tls-key=/path/to/localhost.key
+
+*)
+
+let proxy = "127.0.0.1", 3129
+
+let mypsk = ref None
+
+let ticket_cache = {
+  Tls.Config.lookup = (fun _ -> None) ;
+  ticket_granted = (fun psk epoch -> mypsk := Some (psk, epoch)) ;
+  lifetime = 0l ;
+  timestamp = Ptime_clock.now
+}
+
+let authenticator = null_auth
+let client =
+  Tls.Config.client
+    ~version:(`TLS_1_0, `TLS_1_3)
+    ?cached_ticket:!mypsk
+    ~ticket_cache
+    ~authenticator
+    ~ciphers:Tls.Config.Ciphers.supported
+    ()
+
+let string_prefix ~prefix msg =
+  let len = String.length prefix in
+  String.length msg >= len && String.sub msg 0 len = prefix
+
+let host = Result.get_ok (Domain_name.of_string hostname)
+let host = Result.get_ok (Domain_name.host host)
+
+let test_client _ =
+  (* Connect to proxy *)
+  Tls_lwt.Unix.connect client proxy >>= fun t ->
+  let (ic, oc) = Tls_lwt.of_t t in
+
+  (* Request proxy to connect to hostname *)
+  let req =
+    Printf.sprintf "CONNECT %s:443 HTTP/1.1\r\nHost: %s\r\n\r\n"
+      hostname hostname
+  in
+  Lwt_io.write oc req >>= fun () ->
+  Lwt_io.read ic ~count:1024 >>= fun msg ->
+  assert (string_prefix ~prefix:"HTTP/1.1 200 " msg) ;
+
+  (* TLS with hostname, over the TLS connection with the proxy *)
+  Tls_lwt.Unix.client_of_channels client ~host (ic, oc) >>= fun t ->
+  let (ic, oc) = Tls_lwt.of_t t in
+
+  (* Request homepage from host *)
+  let req =
+    Printf.sprintf "GET / HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n"
+      hostname
+  in
+
+  Lwt_io.(write oc req >>= fun () ->
+          read ~count:1024 ic >>= print >>= fun () ->
+          read ~count:1024 ic >>= print >>= fun () ->
+          close oc >>= fun () ->
+          printf "++ done.\n%!")
+
+let jump _ =
+  try
+    Lwt_main.run (test_client ()) ; `Ok ()
+  with
+  | Tls_lwt.Tls_alert alert as exn ->
+      print_alert "remote end" alert ; raise exn
+  | Tls_lwt.Tls_failure alert as exn ->
+      print_fail "our end" alert ; raise exn
+
+open Cmdliner
+
+let cmd =
+  let term = Term.(ret (const jump $ setup_log))
+  and info = Cmd.info "tls_over_tls" ~version:"%%VERSION_NUM%%"
+  in
+  Cmd.v info term
+
+let () = exit (Cmd.eval cmd)

--- a/lwt/tls_lwt.ml
+++ b/lwt/tls_lwt.ml
@@ -284,7 +284,6 @@ module Unix = struct
   let client_of_fd config ?host fd =
     client_of_fd config ?host (Lwt_fd.of_fd fd)
 
-
   let accept conf fd =
     Lwt_unix.accept fd >>= fun (fd', addr) ->
     Lwt.catch (fun () -> server_of_fd conf fd' >|= fun t -> (t, addr))
@@ -322,7 +321,6 @@ module Unix = struct
     | `Active tls | `Read_closed tls | `Write_closed tls -> Tls.Engine.epoch tls
     | `Closed | `Error _ -> Error ()
 end
-
 
 type ic = Lwt_io.input_channel
 type oc = Lwt_io.output_channel

--- a/lwt/tls_lwt.ml
+++ b/lwt/tls_lwt.ml
@@ -35,10 +35,42 @@ module Lwt_cs = struct
   let read fd buf = read fd buf 0 (Bytes.length buf)
 end
 
+module Lwt_fd = struct
+  type t = {
+    read  : bytes -> int Lwt.t ;
+    write : string -> unit Lwt.t ;
+    close : unit -> unit Lwt.t ;
+  }
+
+  let read t cs = t.read cs
+  let write t cs = t.write cs
+  let close t = t.close ()
+
+  let of_fd fd =
+    let close () =
+      (* (partially) avoid double-closes by checking if the fd has already been closed *)
+      match Lwt_unix.state fd with
+      | Lwt_unix.Closed -> Lwt.return_unit
+      | Lwt_unix.Opened | Lwt_unix.Aborted _ -> Lwt_unix.close fd
+    in
+    {
+      read  = Lwt_cs.read fd ;
+      write = Lwt_cs.write_full fd ;
+      close = close ;
+    }
+
+  let of_channels ic oc =
+    {
+      read  = (fun bs -> Lwt_io.read_into ic bs 0 (Bytes.length bs)) ;
+      write = (Lwt_io.write oc) ;
+      close = (fun () -> Lwt_io.close oc <&> Lwt_io.close ic) ;
+    }
+end
+
 module Unix = struct
 
   type t = {
-    fd             : Lwt_unix.file_descr ;
+    fd             : Lwt_fd.t ;
     mutable state  : [ `Active of Tls.Engine.state
                      | `Read_closed of Tls.Engine.state
                      | `Write_closed of Tls.Engine.state
@@ -83,7 +115,7 @@ module Unix = struct
               | _ -> t.state <- `Error exn) ;
             Lwt.reraise exn)
     in
-    (recording_errors Lwt_cs.read, recording_errors Lwt_cs.write_full)
+    (recording_errors Lwt_fd.read, recording_errors Lwt_fd.write)
 
   let when_some f = function None -> Lwt.return_unit | Some x -> f x
 
@@ -211,7 +243,7 @@ module Unix = struct
        | _ -> Lwt.return_unit) >>= fun () ->
     t.state <- half_close t.state mode;
     match t.state with
-    | `Closed | `Error _ -> safely (Lwt_unix.close t.fd)
+    | `Closed | `Error _ -> safely (Lwt_fd.close t.fd)
     | _ -> Lwt.return_unit
 
   let close t = shutdown t `read_write
@@ -219,7 +251,7 @@ module Unix = struct
   let server_of_fd config fd =
     drain_handshake {
       state    = `Active (Tls.Engine.server config) ;
-      fd       = fd ;
+      fd       = Lwt_fd.of_fd fd ;
       linger   = None ;
       recv_buf = Bytes.create 4096
     }
@@ -239,6 +271,13 @@ module Unix = struct
     in
     write_t t init >>= fun () ->
     drain_handshake t
+
+  let client_of_channels config ?host (ic, oc) =
+    client_of_fd config ?host (Lwt_fd.of_channels ic oc)
+
+  let client_of_fd config ?host fd =
+    client_of_fd config ?host (Lwt_fd.of_fd fd)
+
 
   let accept conf fd =
     Lwt_unix.accept fd >>= fun (fd', addr) ->
@@ -285,11 +324,7 @@ type oc = Lwt_io.output_channel
 let of_t ?close t =
   let close = match close with
     | Some f -> (fun () -> Unix.safely (f ()))
-    | None   -> (fun () ->
-        (* (partially) avoid double-closes by checking if the fd has already been closed *)
-        match Lwt_unix.state t.Unix.fd with
-        | Lwt_unix.Closed -> Lwt.return_unit
-        | Lwt_unix.Opened | Lwt_unix.Aborted _ -> Unix.(safely (close t)))
+    | None   -> (fun () -> Unix.(safely (close t)))
   in
   (Lwt_io.make ~close ~mode:Lwt_io.Input (Unix.read_bytes t)),
   (Lwt_io.make ~close ~mode:Lwt_io.Output @@

--- a/lwt/tls_lwt.ml
+++ b/lwt/tls_lwt.ml
@@ -251,10 +251,16 @@ module Unix = struct
   let server_of_fd config fd =
     drain_handshake {
       state    = `Active (Tls.Engine.server config) ;
-      fd       = Lwt_fd.of_fd fd ;
+      fd       = fd ;
       linger   = None ;
       recv_buf = Bytes.create 4096
     }
+
+  let server_of_channels config (ic, oc) =
+    server_of_fd config (Lwt_fd.of_channels ic oc)
+
+  let server_of_fd config fd =
+    server_of_fd config (Lwt_fd.of_fd fd)
 
   let client_of_fd config ?host fd =
     let config' = match host with

--- a/lwt/tls_lwt.mli
+++ b/lwt/tls_lwt.mli
@@ -29,12 +29,16 @@ module Unix : sig
       handshake of [fd] using [server] configuration. *)
   val server_of_fd : Tls.Config.server -> Lwt_unix.file_descr -> t Lwt.t
 
+  (** [server_of_channels server (ic, oc)] is [t], after server-side TLS
+      handshake on the input/output channels [ic, oc] using [server] configuration. *)
+  val server_of_channels : Tls.Config.server -> Lwt_io.input_channel * Lwt_io.output_channel -> t Lwt.t
+
   (** [client_of_fd client ~host fd] is [t], after client-side
       TLS handshake of [fd] using [client] configuration and [host]. *)
   val client_of_fd : Tls.Config.client -> ?host:[ `host ] Domain_name.t -> Lwt_unix.file_descr -> t Lwt.t
 
-  (** [client_of_channels client ~host ic oc] is [t], after client-side
-      TLS handshake over the channels [ic],[oc] using [client] configuration and [host]. *)
+  (** [client_of_channels client ~host (ic, oc)] is [t], after client-side
+      TLS handshake over the input/output channels [ic, oc] using [client] configuration and [host]. *)
   val client_of_channels : Tls.Config.client -> ?host:[ `host ] Domain_name.t -> Lwt_io.input_channel * Lwt_io.output_channel -> t Lwt.t
 
   (** [accept server fd] is [t, sockaddr], after accepting a

--- a/lwt/tls_lwt.mli
+++ b/lwt/tls_lwt.mli
@@ -33,6 +33,10 @@ module Unix : sig
       TLS handshake of [fd] using [client] configuration and [host]. *)
   val client_of_fd : Tls.Config.client -> ?host:[ `host ] Domain_name.t -> Lwt_unix.file_descr -> t Lwt.t
 
+  (** [client_of_channels client ~host ic oc] is [t], after client-side
+      TLS handshake over the channels [ic],[oc] using [client] configuration and [host]. *)
+  val client_of_channels : Tls.Config.client -> ?host:[ `host ] Domain_name.t -> Lwt_io.input_channel * Lwt_io.output_channel -> t Lwt.t
+
   (** [accept server fd] is [t, sockaddr], after accepting a
       client on [fd] and upgrading to a TLS connection. *)
   val accept  : Tls.Config.server -> Lwt_unix.file_descr -> (t * Lwt_unix.sockaddr) Lwt.t


### PR DESCRIPTION
With @MisterDA , we have a use-case which requires TLS tunneling over an existing TLS connection. This should be pretty easy, but the current `tls-lwt` API only allow TLS negotiation over an `Lwt_unix.file_descr` which limits our ability to use an existing TLS connection as the carrier. This PR adds a new `Tls_lwt.Unix.client_of_channels` function to establish the TLS over input/output `Lwt_io.channel` instead, which were potentially created by a previous TLS.

To explain why TLS-over-TLS is useful, I've attached an example to show how HTTPS proxying work:
- The client first does an HTTPS request to the proxy, and ask it to `CONNECT to_some_server.net:443`
- The proxy hopefully responds with a `200 OK` success code after connecting to the server
- From there, the TLS connection with the proxy remains open, but further messages on that socket are transparently relayed by the proxy between the client and server
- To send an HTTPS request to the now-reachable target server, the client must do a new TLS negotiation with that server (over the existing TLS connection with the proxy)

(Note that this mode of proxying is rather nice as it guarantees that the proxy can't do a man-in-the-middle, since the client is in charge of checking that the nested TLS connection has been established with the expected server certificates!)

I would like to rebase this PR on top of https://github.com/mirleft/ocaml-tls/pull/497 to get rid of the cstructs, but in the meantime, let me know if there's anything else that should be changed! :)