### PR TITLE
tests/feedback: fix for TLS 1.3, run as test

### DIFF
--- a/async/examples/dune
+++ b/async/examples/dune
@@ -1,11 +1,15 @@
 (executable
   (name    test_client)
   (modules test_client)
+  (public_name tls-test-client)
+  (package tls-async)
   (preprocess (pps ppx_jane))
   (libraries async core core_unix.command_unix tls-async))
 
 (executable
   (name    test_server)
   (modules test_server)
+  (public_name tls-test-server)
+  (package tls-async)
   (preprocess (pps ppx_jane))
   (libraries async core core_unix.command_unix tls-async))

--- a/lwt/examples/dune
+++ b/lwt/examples/dune
@@ -1,6 +1,6 @@
 (library
  (name ex_common)
- (libraries lwt lwt.unix sexplib tls tls-lwt cmdliner fmt.cli logs.fmt fmt.tty logs.cli)
+ (libraries lwt lwt.unix tls tls-lwt cmdliner fmt.cli logs.fmt fmt.tty logs.cli)
  (modules ex_common))
 
 (executable

--- a/tests/dune
+++ b/tests/dune
@@ -18,6 +18,7 @@
 
 (test
  (name feedback)
+ (package tls)
  (modules feedback)
  (deps server.key server.pem)
  (libraries tls x509 testlib cmdliner fmt.cli logs.fmt fmt.tty logs.cli))

--- a/tests/dune
+++ b/tests/dune
@@ -16,7 +16,8 @@
  (modules key_derivation)
  (libraries tls mirage-crypto-rng.unix alcotest logs.fmt))
 
-(executable
+(test
  (name feedback)
  (modules feedback)
- (libraries tls x509 testlib))
+ (deps server.key server.pem)
+ (libraries tls x509 testlib cmdliner fmt.cli logs.fmt fmt.tty logs.cli))

--- a/tests/server.key
+++ b/tests/server.key
@@ -1,0 +1,1 @@
+../certificates/server.key

--- a/tests/server.pem
+++ b/tests/server.pem
@@ -1,0 +1,1 @@
+../certificates/server.pem

--- a/tls-async.opam
+++ b/tls-async.opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.14.0"}
   "dune" {>= "3.0"}
   "tls" {= version}
   "x509" {>= "0.14.0"}
@@ -22,6 +22,7 @@ depends: [
   "async" {>= "v0.16"}
   "async_unix" {>= "v0.16"}
   "core" {>= "v0.16"}
+  "core_unix" {>= "v0.16"}
   "cstruct-async"
   "ppx_jane" {>= "v0.16"}
   "mirage-crypto-rng-async" {< "1.0.0"}

--- a/tls.opam
+++ b/tls.opam
@@ -30,6 +30,7 @@ depends: [
   "logs"
   "ipaddr"
   "alcotest" {with-test}
+  "cmdliner" {with-test & >= "1.3.0"}
 ]
 conflicts: [ "result" {< "1.5"} ]
 tags: [ "org:mirage"]


### PR DESCRIPTION
- fix feedback to finish the handshake until server and client are ready Previously, it was only waited until client is ready. This in not sufficient for the TLS 1.3 state machine. In TLS < 1.3, the server sends a final "Finished" message, while in TLS 1.3, the client sends the final "Finished" message. In feedback operations, this was dropped, leading to MAC mismatch.
- tests/server.{key,pem} are symbolic links to ../certificates/server.{key,pem}
- tests/feedback.exe is run as test now
- tests/feedback.exe uses cmdliner and logs now

//cc @dinosaure this fixes feedback for the current main branch. I'll soon rebase the #497 PR on top of this to figure out whether this is fixed then there as well.