### PR TITLE
allocate less: the case where huge data is sent via send_application_data

### DIFF
--- a/lib/crypto.ml
+++ b/lib/crypto.ml
@@ -101,7 +101,7 @@ let pseudo_header seq ty (v_major, v_minor) v_length =
 (* MAC used in TLS *)
 let mac hash key pseudo_hdr data =
   let module H = (val Digestif.module_of_hash' hash) in
-  H.(to_raw_string (hmac_string ~key (pseudo_hdr ^ data)))
+  H.(to_raw_string (hmacv_string ~key [ pseudo_hdr ; data ]))
 
 let cbc_block (type a) cipher =
   let module C = (val cipher : Block.CBC with type key = a) in C.block_size

--- a/lib/engine.ml
+++ b/lib/engine.ml
@@ -300,7 +300,7 @@ let encrypt_records encryptor version records =
           doit st ((ty, buf) :: acc) (off + len)
         else
           let st, ty, buf = encrypt version st ty buf off (bufl - off) in
-          st, List.rev ((ty, buf) :: acc)
+          st, (ty, buf) :: acc
       in
       let st, res =
         if String.length buf >= 1 lsl 14 then

--- a/lib/engine.ml
+++ b/lib/engine.ml
@@ -297,7 +297,7 @@ let encrypt_records encryptor version records =
         if bufl - off >= 1 lsl 14 then
           let len = 1 lsl 14 in
           let st, ty, buf = encrypt version st ty buf off len in
-          doit st ((ty, buf) :: acc) (off + len)
+          (doit [@tailcall]) st ((ty, buf) :: acc) (off + len)
         else
           let st, ty, buf = encrypt version st ty buf off (bufl - off) in
           st, (ty, buf) :: acc
@@ -311,7 +311,7 @@ let encrypt_records encryptor version records =
           in
           st, [ ty, buf ]
       in
-      crypt st (res @ acc) rest
+      (crypt [@tailcall]) st (res @ acc) rest
   in
   crypt encryptor [] records
 

--- a/lib/engine.ml
+++ b/lib/engine.ml
@@ -111,7 +111,7 @@ let encrypt (version : tls_version) (st : crypto_state) ty buf off len =
           match ctx.cipher_st with
           | CBC c ->
              let enc iv =
-               (* TODO only until digestig goes beyond 1.2.0 (feedable hmac) *)
+               (* TODO only until digestif goes beyond 1.2.0 (feedable hmac) *)
                let data = String.sub buf off len in
                let signature = Crypto.mac c.hmac c.hmac_secret pseudo_hdr buf in
                let to_encrypt = data ^ signature in
@@ -302,15 +302,7 @@ let encrypt_records encryptor version records =
           let st, ty, buf = encrypt version st ty buf off (bufl - off) in
           st, (ty, buf) :: acc
       in
-      let st, res =
-        if String.length buf >= 1 lsl 14 then
-          doit st [] 0
-        else
-          let st, ty, buf =
-            encrypt version st ty buf 0 (String.length buf)
-          in
-          st, [ ty, buf ]
-      in
+      let st, res = doit st [] 0 in
       (crypt [@tailcall]) st (res @ acc) rest
   in
   crypt encryptor [] records


### PR DESCRIPTION
previously, we had a nearly exponential blowup at the border of 1 lsl 14 where the data was cut into pieces (but we still hold our hands at the old data)