### PR TITLE
Add an unix implementation of TLS

### DIFF
--- a/miou/tls_miou_unix.ml
+++ b/miou/tls_miou_unix.ml
@@ -1,3 +1,5 @@
+(* NOTE: the unix/tls_unix.ml is mostly copied from here, so any change should be synchronized. *)
+
 let src = Logs.Src.create "tls-miou"
 
 module Log = (val Logs.src_log src : Logs.LOG)

--- a/tls.opam
+++ b/tls.opam
@@ -29,6 +29,7 @@ depends: [
   "ipaddr"
   "ohex" {>= "0.2.0"}
   "digestif" {>= "1.2.0"}
+  "ptime" {>= "1.2.0"}
   "alcotest" {with-test}
   "cmdliner" {with-test & >= "1.3.0"}
 ]

--- a/unix/dune
+++ b/unix/dune
@@ -1,0 +1,5 @@
+(library
+ (name tls_unix)
+ (public_name tls.unix)
+ (wrapped false)
+ (libraries tls unix ptime.clock.os mirage-crypto-rng.unix))

--- a/unix/tls_unix.ml
+++ b/unix/tls_unix.ml
@@ -1,206 +1,337 @@
-type error =
-  | Alert of Tls.Packet.alert_type
-  | Failure of Tls.Engine.failure
-  | Unix_error of Unix.error * string * string
-  | Closed
+let src = Logs.Src.create "tls-miou"
 
-let pp_error ppf = function
-  | Alert alert ->
-      Fmt.pf ppf "TLS alert: %s" (Tls.Packet.alert_type_to_string alert)
-  | Failure failure ->
-      Fmt.pf ppf "TLS failure: %s" (Tls.Engine.string_of_failure failure)
-  | Unix_error (err, f, arg) ->
-      Fmt.pf ppf "%s(%s): %s" f arg (Unix.error_message err)
-  | Closed -> Fmt.pf ppf "Connection closed by peer"
+module Log = (val Logs.src_log src : Logs.LOG)
 
-(* syscalls *)
+external reraise : exn -> 'a = "%reraise"
 
-let rec fully_write socket str off len =
-  if len > 0
-  then
-    let len' = Unix.write socket (Bytes.unsafe_of_string str) off len in
-    fully_write socket str (off + len') (len - len')
+let ( $ ) f x = f x
 
-let fully_write socket ({ Cstruct.len; _ } as cs) =
-  try
-    fully_write socket (Cstruct.to_string cs) 0 len ;
-    Ok ()
-  with Unix.Unix_error (err, f, arg) -> Error (Unix_error (err, f, arg))
+exception Tls_alert of Tls.Packet.alert_type
+exception Tls_failure of Tls.Engine.failure
+exception Closed_by_peer
 
-let read socket =
-  let buf = Bytes.create 0x1000 in
-  match Unix.read socket buf 0 (Bytes.length buf) with
-  | 0 -> Ok `Eof
-  | len -> Ok (`Data (Cstruct.of_bytes ~off:0 ~len buf))
-  | exception Unix.Unix_error (err, f, arg) ->
-      Error (Unix_error (err, f, arg))
+let () =
+  Printexc.register_printer @@ function
+  | Closed_by_peer -> Some "Connection closed by peer"
+  | Tls_alert alert -> Some (Tls.Packet.alert_type_to_string alert)
+  | Tls_failure failure -> Some (Tls.Engine.string_of_failure failure)
+  | _ -> None
 
-  type flow = {
-    role           : [ `Server | `Client ] ;
-    flow           : Unix.file_descr ;
-    mutable state  : [ `Active of Tls.Engine.state
-                     | `Eof
-                     | `Error of error ] ;
-    mutable linger : Cstruct.t list ;
-  }
+type state =
+  [ `Active of Tls.Engine.state
+  | `Read_closed of Tls.Engine.state
+  | `Write_closed of Tls.Engine.state
+  | `Closed
+  | `Error of exn ]
 
-  let tls_alert a = `Error (Alert a)
-  let tls_fail f  = `Error (Failure f)
+type t = {
+  role : [ `Server | `Client ];
+  fd : Unix.file_descr;
+  mutable state : state;
+  mutable linger : string option;
+  read_buffer_size : int;
+  buf : bytes;
+  mutable rd_closed : bool;
+}
 
-  let list_of_option = function None -> [] | Some x -> [x]
+let file_descr { fd; _ } = fd
 
-  let lift_read_result = function
-    | Ok (`Data _ | `Eof as x) -> x
-    | Error e                  -> `Error e
+let half_close state mode =
+  match (state, mode) with
+  | `Active tls, `read -> `Read_closed tls
+  | `Active tls, `write -> `Write_closed tls
+  | `Active _, `read_write -> `Closed
+  | `Read_closed tls, `read -> `Read_closed tls
+  | `Read_closed _, (`write | `read_write) -> `Closed
+  | `Write_closed tls, `write -> `Write_closed tls
+  | `Write_closed _, (`read | `read_write) -> `Closed
+  | ((`Closed | `Error _) as e), (`read | `write | `read_write) -> e
 
-  let lift_write_result = function
-    | Ok ()   -> `Ok ()
-    | Error e -> `Error e
+let inject_state tls = function
+  | `Active _ -> `Active tls
+  | `Read_closed _ -> `Read_closed tls
+  | `Write_closed _ -> `Write_closed tls
+  | (`Closed | `Error _) as e -> e
 
-  let check_write flow f_res =
-    let res = lift_write_result f_res in
-    ( match flow.state, res with
-      | `Active _, (`Eof | `Error _ as e) ->
-          flow.state <- e ; Unix.close flow.flow
-      | _ -> ()) ;
-    match f_res with
-    | Ok ()   -> Ok ()
-    | Error e -> Error e
+let tls_alert a = Tls_alert a
+let tls_fail f = Tls_failure f
+let inhibit fn v = try fn v with _ -> ()
 
-  let read_react flow =
+let rec unix_write fd str off len =
+  let written = Unix.write_substring fd str off len in
+  if not (Int.equal written len) then
+    unix_write fd str (off + written) (len - written)
 
-    let handle tls buf =
-      match Tls.Engine.handle_tls tls buf with
-      | Ok (res, `Response resp, `Data data) ->
-          flow.state <- ( match res with
-            | `Ok tls      -> `Active tls
-            | `Eof         -> `Eof
-            | `Alert alert -> tls_alert alert );
-          ignore ( match resp with
-            | None     -> Ok ()
-            | Some buf -> fully_write flow.flow buf |> check_write flow ) ;
-          ignore ( match res with
-            | `Ok _ -> ()
-            | _     -> Unix.close flow.flow ) ;
-          `Ok data
-      | Error (fail, `Response resp) ->
-          let reason = tls_fail fail in
-          flow.state <- reason ;
-          fully_write flow.flow resp |> fun _ -> Unix.close flow.flow |> fun () -> reason
-    in
-    match flow.state with
-    | `Eof | `Error _ as e -> e
-    | `Active _            ->
-      read flow.flow |> lift_read_result |>
-      function
-      | `Eof | `Error _ as e -> flow.state <- e ; e
-      | `Data buf            -> match flow.state with
-        | `Active tls          -> handle tls buf
-        | `Eof | `Error _ as e -> e
+let write flow str =
+  Log.debug (fun m -> m "try to write %d byte(s)" (String.length str));
+  try unix_write flow.fd str 0 (String.length str) with
+  | Unix.Unix_error ((Unix.EPIPE | Unix.ECONNRESET), _, _) ->
+      flow.state <- half_close flow.state `write;
+      raise Closed_by_peer
+  | Unix.Unix_error (_, _, _) as exn ->
+      flow.state <- `Error exn;
+      reraise exn
 
-  let rec read flow =
-    match flow.linger with
-    | [] ->
-      ( read_react flow |> function
-          | `Ok None       -> read flow
-          | `Ok (Some buf) -> Ok (`Data buf)
-          | `Eof           -> Ok `Eof
-          | `Error e       -> Error e )
-    | bufs ->
-      flow.linger <- [] ;
-      Ok (`Data (Cstruct.concat @@ List.rev bufs))
+let handle flow tls str =
+  match Tls.Engine.handle_tls tls str with
+  | Ok (state, eof, `Response resp, `Data data) ->
+      Log.debug (fun m -> m "We handled %d byte(s)" (String.length str));
+      let state = inject_state state flow.state in
+      let state = Option.(value ~default:state (map (fun `Eof -> half_close state `read) eof)) in
+      flow.state <- state;
+      let to_close = flow.state = `Closed in
+      Option.iter (inhibit $ write flow) resp;
+      (* NOTE(dinosaure): [write flow] can set [flow.state]. So we must
+         check if the actual [flow.state] or the [flow.state] after [write flow]
+         want to close the underlying file-descriptor. *)
+      if to_close || flow.state = `Closed then Unix.close flow.fd;
+      data
+  | Error (fail, `Response resp) ->
+      let exn = match fail with
+        | `Alert a -> tls_alert a | f -> tls_fail f in
+      flow.state <- `Error exn;
+      let _ = inhibit (write flow) resp in
+      raise exn
 
-  let writev flow bufs =
-    match flow.state with
-    | `Eof     -> Error Closed
-    | `Error e -> Error e
-    | `Active tls ->
-        match Tls.Engine.send_application_data tls bufs with
-        | Some (tls, answer) ->
-            flow.state <- `Active tls ;
-            fully_write flow.flow answer |> check_write flow
-        | None ->
-            (* "Impossible" due to handshake draining. *)
-            assert false
+let read flow =
+  match Unix.read flow.fd flow.buf 0 (Bytes.length flow.buf) with
+  | 0 -> Ok String.empty
+  | len -> Ok (Bytes.sub_string flow.buf 0 len)
+  | exception Unix.Unix_error (Unix.ECONNRESET, _, _) -> Ok String.empty
+  | exception exn -> Error exn
 
-  let write flow buf = writev flow [buf]
+let not_errored = function `Error _ -> false | _ -> true
 
-  (*
-   * XXX bad XXX
-   * This is a point that should particularly be protected from concurrent r/w.
-   * Doing this before a `t` is returned is safe; redoing it during rekeying is
-   * not, as the API client already sees the `t` and can mistakenly interleave
-   * writes while this is in progress.
-   * *)
-  let rec drain_handshake flow =
-    match flow.state with
-    | `Active tls when not (Tls.Engine.handshake_in_progress tls) ->
-        Ok flow
-    | _ ->
-      (* read_react re-throws *)
-        read_react flow |> function
-        | `Ok mbuf ->
-            flow.linger <- list_of_option mbuf @ flow.linger ;
-            drain_handshake flow
-        | `Error e -> Error e
-        | `Eof     -> Error Closed
+let garbage flow = match flow.linger with
+  | Some "" | None -> false
+  | _ -> true
 
-  let reneg ?authenticator ?acceptable_cas ?cert ?(drop = true) flow =
-    match flow.state with
-    | `Eof        -> Error Closed
-    | `Error e    -> Error e
-    | `Active tls ->
-        match Tls.Engine.reneg ?authenticator ?acceptable_cas ?cert tls with
-        | None             ->
-            (* XXX make this impossible to reach *)
-            invalid_arg "Renegotiation already in progress"
-        | Some (tls', buf) ->
-            if drop then flow.linger <- [] ;
-            flow.state <- `Active tls' ;
-            fully_write flow.flow buf |> fun _ ->
-            drain_handshake flow |> function
-            | Ok _         -> Ok ()
-            | Error _ as e -> e
+let read_react flow =
+  match flow.state with
+  | `Error exn -> raise exn
+  | `Read_closed _ | `Closed when garbage flow ->
+    (* XXX(dinosaure): [`Closed] can appear "at the same time" than some
+       application-data. In that case, we stored them into [t.linger]. Depending
+       on who closed the connection, [read_react] gives this /garbage/ in any
+       situation (even if the user closed the connection).
 
-  let key_update ?request flow =
-    match flow.state with
-    | `Eof        -> Error Closed
-    | `Error e    -> Error e
-    | `Active tls ->
-      match Tls.Engine.key_update ?request tls with
-      | Error _ -> invalid_arg "Key update failed"
-      | Ok (tls', buf) ->
-        flow.state <- `Active tls' ;
-        fully_write flow.flow buf |> check_write flow
+       An extra layer with [read] below check if [`Read_closed]/[`Close] comes
+       from the network (the peer closed the connection) or the user. In the
+       first case, we must give pending application-data. In the second case,
+       we must return [0] (or raise [End_of_file]). *)
+    let mbuf = flow.linger in
+    flow.linger <- None;
+    mbuf
+  | `Read_closed _ | `Closed ->
+    (* XXX(dinosaure): the goal of [read_react] is to read some encrypted bytes
+       and try to decrypt them with [handle]. If the linger is empty, this means
+       that we're trying to get more data (to decrypt) when we can't get any
+       more. From this point of view, it's an error that needs to be notified.
+       However, this error can be interpreted in 2 ways:
+       - we want to have more data decrypted. In this case, this error is
+         expected and may result in the user being told that there is nothing
+         left to read (for example, returning 0).
+       - we attempt a handshake. In this case, we are dealing with an unexpected
+         error. *)
+    raise End_of_file
+  | `Active _ | `Write_closed _ ->
+    Log.debug (fun m -> m "read something from the TLS session");
+    match read flow with
+    | Error exn ->
+      if not_errored flow.state then flow.state <- `Error exn;
+      raise exn
+    | Ok "" ->
+      (* XXX(dinosaure): see [`Read_closed _ | `Closed] case. *)
+      raise End_of_file
+    | Ok str ->
+      Log.debug (fun m -> m "got %d byte(s)" (String.length str));
+      match flow.state with
+      | `Active tls | `Read_closed tls | `Write_closed tls -> handle flow tls str
+      | `Closed -> raise End_of_file
+      | `Error exn -> raise exn
+[@@ocamlformat "disable"]
 
-  let close flow =
-    match flow.state with
-    | `Active tls ->
-      flow.state <- `Eof ;
-      let (_, buf) = Tls.Engine.send_close_notify tls in
-      fully_write flow.flow buf |> fun _ -> Unix.close flow.flow
-    | _           -> ()
+let rec read_in flow ?(off= 0) ?len buf =
+  let len = Option.value ~default:(Bytes.length buf - off) len in
+  let write_in res =
+    let rlen = String.length res in
+    let mlen = min len rlen in
+    Bytes.blit_string res 0 buf off mlen;
+    let linger = if mlen < rlen
+      then Some (String.sub res mlen (rlen - mlen))
+      else None in
+    flow.linger <- linger; mlen
+  in
+  match flow.linger with
+  | Some res -> write_in res
+  | None -> (
+      match read_react flow with
+      | None -> read_in ~off ~len flow buf
+      | Some res -> write_in res)
 
-  let client_of_flow conf ?host flow =
-    let conf' = match host with
-      | None      -> conf
-      | Some host -> Tls.Config.peer conf host
-    in
-    let (tls, init) = Tls.Engine.client conf' in
-    let tls_flow = {
-      role   = `Client ;
-      flow   = flow ;
-      state  = `Active tls ;
-      linger = [] ;
-    } in
-    fully_write flow init |> fun _ -> drain_handshake tls_flow
+let writev flow bufs =
+  match flow.state with
+  | `Closed | `Write_closed _ -> raise Closed_by_peer
+  | `Error exn -> reraise exn
+  | `Active tls | `Read_closed tls -> (
+      match Tls.Engine.send_application_data tls bufs with
+      | Some (tls, answer) ->
+          flow.state <- inject_state tls flow.state;
+          write flow answer
+      | None -> assert false)
 
-  let server_of_flow conf flow =
-    let tls_flow = {
-      role   = `Server ;
-      flow   = flow ;
-      state  = `Active (Tls.Engine.server conf) ;
-      linger = [] ;
-    } in
-    drain_handshake tls_flow
+let rec drain_handshake flow =
+  let push_linger flow mcs =
+    match (mcs, flow.linger) with
+    | None, _ -> ()
+    | scs, None -> flow.linger <- scs
+    | Some cs, Some l -> flow.linger <- Some (l ^ cs)
+  in
+  match flow.state with
+  | `Active tls when not (Tls.Engine.handshake_in_progress tls) -> flow
+  | (`Read_closed _ | `Closed) when garbage flow -> flow
+  | _ ->
+      Log.debug (fun m -> m "start to read something from the TLS session");
+      let mcs = read_react flow in
+      push_linger flow mcs;
+      drain_handshake flow
 
+let close flow =
+  match flow.state with
+  | `Active tls | `Read_closed tls ->
+      let tls, str = Tls.Engine.send_close_notify tls in
+      flow.rd_closed <- true;
+      flow.state <- inject_state tls flow.state;
+      flow.state <- `Closed;
+      inhibit (write flow) str;
+      Unix.close flow.fd
+  | `Write_closed _ ->
+      flow.rd_closed <- true;
+      flow.state <- `Closed;
+      Unix.close flow.fd
+  | `Closed -> flow.rd_closed <- true
+  | `Error _ ->
+      flow.rd_closed <- true;
+      Unix.close flow.fd
+
+let closed_by_user flow = function
+  | `read | `read_write -> flow.rd_closed <- true
+  | `write -> ()
+
+let shutdown flow mode =
+  closed_by_user flow mode;
+  match (flow.state, mode) with
+  | `Active tls, `read ->
+      Log.debug (fun m -> m "shutdown `read");
+      flow.state <- inject_state tls (half_close flow.state mode)
+  | (`Active tls | `Read_closed tls), (`write | `read_write) ->
+      let tls, str = Tls.Engine.send_close_notify tls in
+      flow.state <- inject_state tls (half_close flow.state mode);
+      (* NOTE(dinosaure): [write flow] can set [flow.state]. So we must
+         check if the actual [flow.state] or the [flow.state] after [write flow]
+         want to close the underlying file-descriptor. *)
+      let to_close = flow.state = `Closed in
+      inhibit (write flow) str;
+      if to_close || flow.state = `Closed then Unix.close flow.fd
+  | `Write_closed tls, (`read | `read_write) ->
+      flow.state <- inject_state tls (half_close flow.state mode);
+      if flow.state = `Closed then Unix.close flow.fd
+  | `Error _, _ -> Unix.close flow.fd
+  | `Read_closed _, `read -> ()
+  | `Write_closed _, `write -> ()
+  | `Closed, _ -> ()
+
+let client_of_fd conf ?(read_buffer_size = 0x1000) ?host fd =
+  let conf' =
+    match host with None -> conf | Some host -> Tls.Config.peer conf host
+  in
+  let tls, init = Tls.Engine.client conf' in
+  let tls_flow =
+    {
+      role = `Client;
+      fd;
+      state = `Active tls;
+      linger = None;
+      read_buffer_size;
+      buf = Bytes.make read_buffer_size '\000';
+      rd_closed = false;
+    }
+  in
+  write tls_flow init;
+  drain_handshake tls_flow
+
+let server_of_fd conf ?(read_buffer_size = 0x1000) fd =
+  let tls = Tls.Engine.server conf in
+  let tls_flow =
+    {
+      role = `Server;
+      fd;
+      state = `Active tls;
+      linger = None;
+      read_buffer_size;
+      buf = Bytes.make read_buffer_size '\000';
+      rd_closed = false;
+    }
+  in
+  drain_handshake tls_flow
+
+let write flow ?(off = 0) ?len str =
+  let len = Option.value ~default:(String.length str - off) len in
+  if off < 0 || len < 0 || off > String.length str - len
+  then invalid_arg "Tls_miou.write";
+  if len > 0 then writev flow [ String.sub str off len ]
+
+let read t ?(off= 0) ?len buf =
+  let len = Option.value ~default:(Bytes.length buf - off) len in
+  if off < 0 || len < 0 || off > Bytes.length buf - len
+  then invalid_arg "Tls_miou.read";
+  if t.rd_closed then 0
+  else try read_in t ~off ~len buf with End_of_file -> 0
+
+let rec really_read_go t off len buf =
+  let len' = read t buf ~off ~len in
+  if len' == 0 then raise End_of_file
+  else if len - len' > 0
+  then really_read_go t (off + len') (len - len') buf
+
+let really_read t ?(off= 0) ?len buf =
+  let len = Option.value ~default:(Bytes.length buf - off) len in
+  if off < 0 || len < 0 || off > Bytes.length buf - len
+  then invalid_arg "Tls_miou.really_read";
+  if len > 0 then really_read_go t off len buf
+
+let resolve host service =
+  let tcp = Unix.getprotobyname "tcp" in
+  match Unix.getaddrinfo host service [ AI_PROTOCOL tcp.p_proto ] with
+  | [] -> Fmt.invalid_arg "No address for %s:%s" host service
+  | ai :: _ -> ai.ai_addr
+
+let connect authenticator (v, port) =
+  let conf =
+    match Tls.Config.client ~authenticator () with
+    | Ok config -> config
+    | Error `Msg msg -> Fmt.invalid_arg "Configuration failure: %s" msg
+  in
+  let addr = resolve v (string_of_int port) in
+  let fd =
+    match addr with
+    | Unix.ADDR_UNIX _ -> invalid_arg "Tls_miou.connect: Invalid UNIX socket"
+    | Unix.ADDR_INET (inet_addr, _) ->
+        if Unix.is_inet6_addr inet_addr then
+          Unix.socket Unix.PF_INET6 Unix.SOCK_STREAM 0
+        else
+          Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0
+  in
+  let host = Result.to_option Domain_name.(Result.bind (of_string v) host) in
+  match Unix.connect fd addr with
+  | () -> client_of_fd conf ?host fd
+  | exception exn ->
+      Unix.close fd;
+      raise exn
+
+let epoch flow = match flow.state with
+  | `Active tls | `Read_closed tls | `Write_closed tls ->
+    ( match Tls.Engine.epoch tls with
+    | Error () -> assert false
+    | Ok data -> Some data )
+  | _ -> None

--- a/unix/tls_unix.ml
+++ b/unix/tls_unix.ml
@@ -1,3 +1,5 @@
+(* NOTE: mostly copied from miou/tls_miou_unix.ml, so any change should be synchronized. *)
+
 let src = Logs.Src.create "tls-unix"
 
 module Log = (val Logs.src_log src : Logs.LOG)

--- a/unix/tls_unix.ml
+++ b/unix/tls_unix.ml
@@ -1,4 +1,4 @@
-let src = Logs.Src.create "tls-miou"
+let src = Logs.Src.create "tls-unix"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
@@ -278,13 +278,13 @@ let server_of_fd conf ?(read_buffer_size = 0x1000) fd =
 let write flow ?(off = 0) ?len str =
   let len = Option.value ~default:(String.length str - off) len in
   if off < 0 || len < 0 || off > String.length str - len
-  then invalid_arg "Tls_miou.write";
+  then invalid_arg "Tls_unix.write";
   if len > 0 then writev flow [ String.sub str off len ]
 
 let read t ?(off= 0) ?len buf =
   let len = Option.value ~default:(Bytes.length buf - off) len in
   if off < 0 || len < 0 || off > Bytes.length buf - len
-  then invalid_arg "Tls_miou.read";
+  then invalid_arg "Tls_unix.read";
   if t.rd_closed then 0
   else try read_in t ~off ~len buf with End_of_file -> 0
 
@@ -297,7 +297,7 @@ let rec really_read_go t off len buf =
 let really_read t ?(off= 0) ?len buf =
   let len = Option.value ~default:(Bytes.length buf - off) len in
   if off < 0 || len < 0 || off > Bytes.length buf - len
-  then invalid_arg "Tls_miou.really_read";
+  then invalid_arg "Tls_unix.really_read";
   if len > 0 then really_read_go t off len buf
 
 let resolve host service =
@@ -315,7 +315,7 @@ let connect authenticator (v, port) =
   let addr = resolve v (string_of_int port) in
   let fd =
     match addr with
-    | Unix.ADDR_UNIX _ -> invalid_arg "Tls_miou.connect: Invalid UNIX socket"
+    | Unix.ADDR_UNIX _ -> invalid_arg "Tls_unix.connect: Invalid UNIX socket"
     | Unix.ADDR_INET (inet_addr, _) ->
         if Unix.is_inet6_addr inet_addr then
           Unix.socket Unix.PF_INET6 Unix.SOCK_STREAM 0

--- a/unix/tls_unix.ml
+++ b/unix/tls_unix.ml
@@ -1,0 +1,177 @@
+type error =
+  | Alert of Tls.Packet.alert_type
+  | Failure of Tls.Engine.failure
+  | Unix_error of Unix.error * string * string
+  | Closed
+
+let pp_error ppf = function
+  | Alert alert ->
+      Fmt.pf ppf "TLS alert: %s" (Tls.Packet.alert_type_to_string alert)
+  | Failure failure ->
+      Fmt.pf ppf "TLS failure: %s" (Tls.Engine.string_of_failure failure)
+  | Unix_error (err, f, arg) ->
+      Fmt.pf ppf "%s(%s): %s" f arg (Unix.error_message err)
+  | Closed -> Fmt.pf ppf "Connection closed by peer"
+
+(* syscalls *)
+
+let rec fully_write socket str off len =
+  if len > 0
+  then
+    let len' = Unix.write socket (Bytes.unsafe_of_string str) off len in
+    fully_write socket str (off + len') (len - len')
+
+let fully_write socket ({ Cstruct.len; _ } as cs) =
+  try
+    fully_write socket (Cstruct.to_string cs) 0 len ;
+    Ok ()
+  with Unix.Unix_error (err, f, arg) -> Error (Unix_error (err, f, arg))
+
+let read socket =
+  let buf = Bytes.create 0x1000 in
+  match Unix.read socket buf 0 (Bytes.length buf) with
+  | 0 -> Ok `Eof
+  | len -> Ok (`Data (Cstruct.of_bytes ~off:0 ~len buf))
+  | exception Unix.Unix_error (err, f, arg) ->
+      Error (Unix_error (err, f, arg))
+
+  type flow = {
+    role           : [ `Server | `Client ] ;
+    flow           : Unix.file_descr ;
+    mutable state  : [ `Active of Tls.Engine.state
+                     | `Eof
+                     | `Error of error ] ;
+    mutable linger : Cstruct.t list ;
+  }
+
+  let tls_alert a = `Error (Alert a)
+  let tls_fail f  = `Error (Failure f)
+
+  let list_of_option = function None -> [] | Some x -> [x]
+
+  let lift_read_result = function
+    | Ok (`Data _ | `Eof as x) -> x
+    | Error e                  -> `Error e
+
+  let lift_write_result = function
+    | Ok ()   -> `Ok ()
+    | Error e -> `Error e
+
+  let check_write flow f_res =
+    let res = lift_write_result f_res in
+    ( match flow.state, res with
+      | `Active _, (`Eof | `Error _ as e) ->
+          flow.state <- e ; Unix.close flow.flow
+      | _ -> ()) ;
+    match f_res with
+    | Ok ()   -> Ok ()
+    | Error e -> Error e
+
+  let read_react flow =
+
+    let handle tls buf =
+      match Tls.Engine.handle_tls tls buf with
+      | Ok (res, `Response resp, `Data data) ->
+          flow.state <- ( match res with
+            | `Ok tls      -> `Active tls
+            | `Eof         -> `Eof
+            | `Alert alert -> tls_alert alert );
+          ignore ( match resp with
+            | None     -> Ok ()
+            | Some buf -> fully_write flow.flow buf |> check_write flow ) ;
+          ignore ( match res with
+            | `Ok _ -> ()
+            | _     -> Unix.close flow.flow ) ;
+          `Ok data
+      | Error (fail, `Response resp) ->
+          let reason = tls_fail fail in
+          flow.state <- reason ;
+          fully_write flow.flow resp |> fun _ -> Unix.close flow.flow |> fun () -> reason
+    in
+    match flow.state with
+    | `Eof | `Error _ as e -> e
+    | `Active _            ->
+      read flow.flow |> lift_read_result |>
+      function
+      | `Eof | `Error _ as e -> flow.state <- e ; e
+      | `Data buf            -> match flow.state with
+        | `Active tls          -> handle tls buf
+        | `Eof | `Error _ as e -> e
+
+  let rec read flow =
+    match flow.linger with
+    | [] ->
+      ( read_react flow |> function
+          | `Ok None       -> read flow
+          | `Ok (Some buf) -> Ok (`Data buf)
+          | `Eof           -> Ok `Eof
+          | `Error e       -> Error e )
+    | bufs ->
+      flow.linger <- [] ;
+      Ok (`Data (Cstruct.concat @@ List.rev bufs))
+
+  let writev flow bufs =
+    match flow.state with
+    | `Eof     -> Error Closed
+    | `Error e -> Error e
+    | `Active tls ->
+        match Tls.Engine.send_application_data tls bufs with
+        | Some (tls, answer) ->
+            flow.state <- `Active tls ;
+            fully_write flow.flow answer |> check_write flow
+        | None ->
+            (* "Impossible" due to handshake draining. *)
+            assert false
+
+  let write flow buf = writev flow [buf]
+
+  (*
+   * XXX bad XXX
+   * This is a point that should particularly be protected from concurrent r/w.
+   * Doing this before a `t` is returned is safe; redoing it during rekeying is
+   * not, as the API client already sees the `t` and can mistakenly interleave
+   * writes while this is in progress.
+   * *)
+  let rec drain_handshake flow =
+    match flow.state with
+    | `Active tls when not (Tls.Engine.handshake_in_progress tls) ->
+        Ok flow
+    | _ ->
+      (* read_react re-throws *)
+        read_react flow |> function
+        | `Ok mbuf ->
+            flow.linger <- list_of_option mbuf @ flow.linger ;
+            drain_handshake flow
+        | `Error e -> Error e
+        | `Eof     -> Error Closed
+  let close flow =
+    match flow.state with
+    | `Active tls ->
+      flow.state <- `Eof ;
+      let (_, buf) = Tls.Engine.send_close_notify tls in
+      fully_write flow.flow buf |> fun _ -> Unix.close flow.flow
+    | _           -> ()
+
+  let client_of_flow conf ?host flow =
+    let conf' = match host with
+      | None      -> conf
+      | Some host -> Tls.Config.peer conf host
+    in
+    let (tls, init) = Tls.Engine.client conf' in
+    let tls_flow = {
+      role   = `Client ;
+      flow   = flow ;
+      state  = `Active tls ;
+      linger = [] ;
+    } in
+    fully_write flow init |> fun _ -> drain_handshake tls_flow
+
+  let server_of_flow conf flow =
+    let tls_flow = {
+      role   = `Server ;
+      flow   = flow ;
+      state  = `Active (Tls.Engine.server conf) ;
+      linger = [] ;
+    } in
+    drain_handshake tls_flow
+

--- a/unix/tls_unix.mli
+++ b/unix/tls_unix.mli
@@ -40,6 +40,20 @@ val close : flow -> unit
 (** [close flow] sends a close notification to the peer and close the
     underlying [Unix] socket. *)
 
+(** [reneg ~authenticator ~acceptable_cas ~cert ~drop t] renegotiates the
+    session, and blocks until the renegotiation finished.  Optionally, a new
+    [authenticator] and [acceptable_cas] can be used.  The own certificate can
+    be adjusted by [cert]. If [drop] is [true] (the default),
+    application data received before the renegotiation finished is dropped. *)
+val reneg : ?authenticator:X509.Authenticator.t ->
+  ?acceptable_cas:X509.Distinguished_name.t list -> ?cert:Tls.Config.own_cert ->
+  ?drop:bool -> flow -> (unit, error) result
+
+(** [key_update ~request t] updates the traffic key and requests a traffic key
+    update from the peer if [request] is provided and [true] (the default).
+    This is only supported in TLS 1.3. *)
+val key_update : ?request:bool -> flow -> (unit, error) result
+
 (** [client_of_flow client ~host socket] upgrades the existing connection
     to TLS using [client] configuration, using [host] as peer name. *)
 val client_of_flow : Tls.Config.client -> ?host:[ `host ] Domain_name.t ->

--- a/unix/tls_unix.mli
+++ b/unix/tls_unix.mli
@@ -1,0 +1,51 @@
+(** Effectful operations using [Unix] for pure TLS. *)
+
+(** possible errors: incoming alert, processing failure, or a
+    problem in the underlying [Unix] flow. *)
+type error =
+  | Alert of Tls.Packet.alert_type
+  | Failure of Tls.Engine.failure
+  | Unix_error of Unix.error * string * string
+  | Closed
+
+val pp_error : Format.formatter -> error -> unit
+(** Pretty-printer of {!val:error}. *)
+
+type flow
+(** The type of flows. *)
+
+val read : flow -> ([ `Data of Cstruct.t | `Eof ], error) result
+(** [read flow] blocks until some data is available and returns a
+    fresh buffer containing it.
+
+    If the remote endpoint calls [close] then calls to [read] will
+    keep returning data until all the {i in-flight} data has been read.
+    [read flow] will return [`Eof] when the remote endpoint has
+    called [close] and when there is no more (i in-flight} data.
+*)
+
+val write : flow -> Cstruct.t -> (unit, error) result
+(** [write flow buffer] writes a buffer to the TLS flow. There is no
+    indication when the buffer has actually been read and, therefore,
+    it must not be reused. The result [Ok ()] indicates success,
+    [Error Closed] indicates that the connection is now closed and
+    therefore the data could not be written. Other errors are possible.
+*)
+
+val writev : flow -> Cstruct.t list -> (unit, error) result
+(** [writev flow bufs] is a successive call of {!val:write} with
+    given [bufs]. *)
+
+val close : flow -> unit
+(** [close flow] sends a close notification to the peer and close the
+    underlying [Unix] socket. *)
+
+(** [client_of_flow client ~host socket] upgrades the existing connection
+    to TLS using [client] configuration, using [host] as peer name. *)
+val client_of_flow : Tls.Config.client -> ?host:[ `host ] Domain_name.t ->
+  Unix.file_descr -> (flow, error) result
+
+(** [server_of_flow server flow] upgrades the flow to a TLS
+    connection using the [server] configuration. *)
+val server_of_flow : Tls.Config.server -> Unix.file_descr ->
+  (flow, error) result


### PR DESCRIPTION
This is an updated version of https://github.com/mirleft/ocaml-tls/pull/443 rebased on top of master.
I then took the current `tls-miou` implementation and replaced `Miou_unix` by `Unix`