### PR TITLE
eio,lwt,mirage: fix drain_handshake on Read_closed/Write_closed states

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+* tls-eio, tls-lwt, tls-mirage, tls-miou-unix, tls-unix: `drain_handshake`
+  now returns once the handshake completes, even if the peer has already
+  closed one half of the connection. It still raises `End_of_file` if the
+  peer closes before the handshake finishes (#520 @samoht)
+
 ## v2.0.4 (2026-03-10)
 
 * Fix exception in parse_change_cipher_spec on empty input (#519 @samoht)

--- a/eio/tls_eio.ml
+++ b/eio/tls_eio.ml
@@ -143,7 +143,8 @@ module Raw = struct
       | (Some cs, Some l) -> t.linger <- Some (Cstruct.append l cs)
     in
     match t.state with
-    | `Active tls when not (Tls.Engine.handshake_in_progress tls) ->
+    | `Active tls | `Read_closed tls | `Write_closed tls
+      when not (Tls.Engine.handshake_in_progress tls) ->
         t
     | _ ->
         let cs = read_react t in

--- a/eio/tls_eio.mli
+++ b/eio/tls_eio.mli
@@ -20,7 +20,11 @@ type t = [ `Tls | Eio.Flow.two_way_ty | Eio.Resource.close_ty ] r
 
     You must ensure a RNG is installed while using TLS, e.g. using [Mirage_crypto_rng_unix.use_default ()].
     Ideally, this would be part of the [server] config so you couldn't forget it,
-    but for now you'll get a runtime error if you forget. *)
+    but for now you'll get a runtime error if you forget.
+
+    Succeeds even if the peer has already closed one half of the connection.
+
+    @raise End_of_file if the peer closes before the handshake completes. *)
 val server_of_flow :
   Tls.Config.server ->
   [> Eio.Flow.two_way_ty | Eio.Resource.close_ty] r -> t
@@ -30,7 +34,11 @@ val server_of_flow :
 
     You must ensure a RNG is installed while using TLS, e.g. using [Mirage_crypto_rng_unix.use_default ()].
     Ideally, this would be part of the [client] config so you couldn't forget it,
-    but for now you'll get a runtime error if you forget. *)
+    but for now you'll get a runtime error if you forget.
+
+    Succeeds even if the peer has already closed one half of the connection.
+
+    @raise End_of_file if the peer closes before the handshake completes. *)
 val client_of_flow :
   Tls.Config.client -> ?host:[ `host ] Domain_name.t ->
   [> Eio.Flow.two_way_ty | Eio.Resource.close_ty] r -> t

--- a/lwt/tests/drain_handshake.ml
+++ b/lwt/tests/drain_handshake.ml
@@ -1,0 +1,58 @@
+open Lwt.Infix
+
+let client_cfg =
+  let null_auth ?ip:_ ~host:_ _ = Ok None in
+  Result.get_ok (Tls.Config.client ~authenticator:null_auth ())
+
+let assert_read_returns_0 flow =
+  let buf = Bytes.create 1 in
+  Tls_lwt.Unix.read flow buf >|= fun n -> assert (n = 0)
+
+let assert_end_of_file f =
+  Lwt.catch
+    (fun () -> f () >|= fun _ -> assert false)
+    (function End_of_file -> Lwt.return_unit | exn -> Lwt.reraise exn)
+
+let pipes () =
+  let client_in, server_out = Lwt_io.pipe () in
+  let server_in, client_out = Lwt_io.pipe () in
+  client_in, client_out, server_in, server_out
+
+let completed_read_closed_reports_eof server_cfg timing =
+  let client_in, client_out, server_in, server_out = pipes () in
+  let client =
+    Tls_lwt.Unix.client_of_channels client_cfg (client_in, client_out)
+  in
+  let server =
+    Tls_lwt.Unix.server_of_channels server_cfg (server_in, server_out)
+  in
+  client >>= fun client ->
+  (match timing with
+   | `Coalesced ->
+       Tls_lwt.Unix.close client >>= fun () ->
+       server
+   | `Split ->
+       Lwt_io.flush client_out >>= fun () ->
+       server >>= fun server ->
+       Tls_lwt.Unix.close client >|= fun () ->
+       server)
+  >>= fun server ->
+  assert_read_returns_0 server
+
+let closed_before_handshake_fails server_cfg =
+  let server_in, client_out = Lwt_io.pipe () in
+  Lwt_io.close client_out >>= fun () ->
+  assert_end_of_file (fun () ->
+      Tls_lwt.Unix.server_of_channels server_cfg (server_in, Lwt_io.null))
+
+let () =
+  Mirage_crypto_rng_unix.use_default ();
+  Lwt_main.run
+    (X509_lwt.private_of_pems ~cert:"server.pem" ~priv_key:"server.key"
+     >>= fun certificate ->
+     let server_cfg =
+       Result.get_ok Tls.Config.(server ~certificates:(`Single certificate) ())
+     in
+     closed_before_handshake_fails server_cfg >>= fun () ->
+     completed_read_closed_reports_eof server_cfg `Split >>= fun () ->
+     completed_read_closed_reports_eof server_cfg `Coalesced)

--- a/lwt/tests/dune
+++ b/lwt/tests/dune
@@ -1,0 +1,8 @@
+(copy_files ../../certificates/server.key)
+(copy_files ../../certificates/server.pem)
+
+(test
+ (name drain_handshake)
+ (package tls-lwt)
+ (deps server.key server.pem)
+ (libraries tls tls-lwt lwt lwt.unix x509 mirage-crypto-rng.unix))

--- a/lwt/tls_lwt.ml
+++ b/lwt/tls_lwt.ml
@@ -200,7 +200,8 @@ module Unix = struct
       | (Some cs, Some l) -> t.linger <- Some (l ^ cs)
     in
     match t.state with
-    | `Active tls when not (Tls.Engine.handshake_in_progress tls) ->
+    | `Active tls | `Read_closed tls | `Write_closed tls
+      when not (Tls.Engine.handshake_in_progress tls) ->
         Lwt.return t
     | _ ->
         read_react t >>= function

--- a/lwt/tls_lwt.mli
+++ b/lwt/tls_lwt.mli
@@ -26,19 +26,37 @@ module Unix : sig
   (** {2 Constructors} *)
 
   (** [server_of_fd server fd] is [t], after server-side TLS
-      handshake of [fd] using [server] configuration. *)
+      handshake of [fd] using [server] configuration.
+
+      Succeeds even if the peer has already closed one half of the connection.
+
+      @raise End_of_file if the peer closes before the handshake completes. *)
   val server_of_fd : Tls.Config.server -> Lwt_unix.file_descr -> t Lwt.t
 
   (** [server_of_channels server (ic, oc)] is [t], after server-side TLS
-      handshake on the input/output channels [ic, oc] using [server] configuration. *)
+      handshake on the input/output channels [ic, oc] using [server]
+      configuration.
+
+      Succeeds even if the peer has already closed one half of the connection.
+
+      @raise End_of_file if the peer closes before the handshake completes. *)
   val server_of_channels : Tls.Config.server -> Lwt_io.input_channel * Lwt_io.output_channel -> t Lwt.t
 
   (** [client_of_fd client ~host fd] is [t], after client-side
-      TLS handshake of [fd] using [client] configuration and [host]. *)
+      TLS handshake of [fd] using [client] configuration and [host].
+
+      Succeeds even if the peer has already closed one half of the connection.
+
+      @raise End_of_file if the peer closes before the handshake completes. *)
   val client_of_fd : Tls.Config.client -> ?host:[ `host ] Domain_name.t -> Lwt_unix.file_descr -> t Lwt.t
 
   (** [client_of_channels client ~host (ic, oc)] is [t], after client-side
-      TLS handshake over the input/output channels [ic, oc] using [client] configuration and [host]. *)
+      TLS handshake over the input/output channels [ic, oc] using [client]
+      configuration and [host].
+
+      Succeeds even if the peer has already closed one half of the connection.
+
+      @raise End_of_file if the peer closes before the handshake completes. *)
   val client_of_channels : Tls.Config.client -> ?host:[ `host ] Domain_name.t -> Lwt_io.input_channel * Lwt_io.output_channel -> t Lwt.t
 
   (** [accept server fd] is [t, sockaddr], after accepting a

--- a/miou/tls_miou_unix.ml
+++ b/miou/tls_miou_unix.ml
@@ -185,7 +185,8 @@ let rec drain_handshake flow =
     | Some cs, Some l -> flow.linger <- Some (l ^ cs)
   in
   match flow.state with
-  | `Active tls when not (Tls.Engine.handshake_in_progress tls) -> flow
+  | `Active tls | `Read_closed tls | `Write_closed tls
+    when not (Tls.Engine.handshake_in_progress tls) -> flow
   | (`Read_closed _ | `Closed) when garbage flow -> flow
   | _ ->
       Log.debug (fun m -> m "start to read something from the TLS session");

--- a/miou/tls_miou_unix.mli
+++ b/miou/tls_miou_unix.mli
@@ -77,14 +77,18 @@ val client_of_fd :
 (** [client_of_flow client ~host fd] is [t], after client-side TLS handshake of
     [fd] using [client] configuration and [host].
 
-    @raise End_of_file if we are not able to complete the handshake. *)
+    Succeeds even if the peer has already closed one half of the connection.
+
+    @raise End_of_file if the peer closes before the handshake completes. *)
 
 val server_of_fd :
   Tls.Config.server -> ?read_buffer_size:int -> Miou_unix.file_descr -> t
 (** [server_of_fd server fd] is [t], after server-side TLS handshake of [fd]
     using [server] configuration.
 
-    @raise End_of_file if we are not able to complete the handshake. *)
+    Succeeds even if the peer has already closed one half of the connection.
+
+    @raise End_of_file if the peer closes before the handshake completes. *)
 
 val connect : X509.Authenticator.t -> string * int -> t
 (** [connect authenticator (host, port)] is [t], a connected TLS connection

--- a/mirage/tls_mirage.ml
+++ b/mirage/tls_mirage.ml
@@ -134,7 +134,8 @@ module Make (F : Mirage_flow.S) = struct
    * *)
   let rec drain_handshake flow =
     match flow.state with
-    | `Active tls when not (Tls.Engine.handshake_in_progress tls) ->
+    | `Active tls | `Read_closed tls | `Write_closed tls
+      when not (Tls.Engine.handshake_in_progress tls) ->
         Lwt.return @@ Ok flow
     | _ ->
       (* read_react re-throws *)

--- a/mirage/tls_mirage.mli
+++ b/mirage/tls_mirage.mli
@@ -37,12 +37,20 @@ module Make (F : Mirage_flow.S) : sig
   val key_update : ?request:bool -> flow -> (unit, [ write_error | `Msg of string ]) result Lwt.t
 
   (** [client_of_flow client ~host flow] upgrades the existing connection
-      to TLS using the [client] configuration, using [host] as peer name. *)
+      to TLS using the [client] configuration, using [host] as peer name.
+
+      Succeeds even if the peer has already closed one half of the connection.
+      Returns [Error `Closed] if the peer closes before the handshake
+      completes. *)
   val client_of_flow : Tls.Config.client -> ?host:[ `host ] Domain_name.t ->
      F.flow -> (flow, write_error) result Lwt.t
 
   (** [server_of_flow server flow] upgrades the flow to a TLS
-      connection using the [server] configuration. *)
+      connection using the [server] configuration.
+
+      Succeeds even if the peer has already closed one half of the connection.
+      Returns [Error `Closed] if the peer closes before the handshake
+      completes. *)
   val server_of_flow : Tls.Config.server -> F.flow ->
     (flow, write_error) result Lwt.t
 

--- a/unix/tls_unix.ml
+++ b/unix/tls_unix.ml
@@ -190,7 +190,8 @@ let rec drain_handshake flow =
     | Some cs, Some l -> flow.linger <- Some (l ^ cs)
   in
   match flow.state with
-  | `Active tls when not (Tls.Engine.handshake_in_progress tls) -> flow
+  | `Active tls | `Read_closed tls | `Write_closed tls
+    when not (Tls.Engine.handshake_in_progress tls) -> flow
   | (`Read_closed _ | `Closed) when garbage flow -> flow
   | _ ->
       Log.debug (fun m -> m "start to read something from the TLS session");

--- a/unix/tls_unix.mli
+++ b/unix/tls_unix.mli
@@ -77,14 +77,18 @@ val client_of_fd :
 (** [client_of_flow client ~host fd] is [t], after client-side TLS handshake of
     [fd] using [client] configuration and [host].
 
-    @raise End_of_file if we are not able to complete the handshake. *)
+    Succeeds even if the peer has already closed one half of the connection.
+
+    @raise End_of_file if the peer closes before the handshake completes. *)
 
 val server_of_fd :
   Tls.Config.server -> ?read_buffer_size:int -> Unix.file_descr -> t
 (** [server_of_fd server fd] is [t], after server-side TLS handshake of [fd]
     using [server] configuration.
 
-    @raise End_of_file if we are not able to complete the handshake. *)
+    Succeeds even if the peer has already closed one half of the connection.
+
+    @raise End_of_file if the peer closes before the handshake completes. *)
 
 val connect : X509.Authenticator.t -> string * int -> t
 (** [connect authenticator (host, port)] is [t], a connected TLS connection


### PR DESCRIPTION
Note: I am not totally sure this is the right fix -- I have been seeing this while writing larger e2e tests using eio (but I noticed the other backends had the same issue). I can add a minimal test that reproduces this for eio if needed (but there is no exiring infrastucture in the repo to test this I think?)