### PR TITLE
Similar to ?host, allow an ?ip in client_of_fd in all backends

### DIFF
--- a/async/io.ml
+++ b/async/io.ml
@@ -176,11 +176,16 @@ module Make (Fd : Fd) : S with module Fd := Fd = struct
       }
   ;;
 
-  let client_of_fd config ?host fd =
-    let config' =
+  let client_of_fd config ?host ?ip fd =
+    let config =
       match host with
       | None -> config
       | Some host -> Tls.Config.peer config host
+    in
+    let config' =
+      match ip with
+      | None -> config
+      | Some ip -> Tls.Config.ip config ip
     in
     let t = { state = Eof; fd; linger = None; recv_buf = Bytes.create 4096 } in
     let tls, init = Tls.Engine.client config' in

--- a/async/io_intf.ml
+++ b/async/io_intf.ml
@@ -25,6 +25,7 @@ module type S = sig
   val client_of_fd
     :  Tls.Config.client
     -> ?host:[ `host ] Domain_name.t
+    -> ?ip:Ipaddr.t
     -> Fd.t
     -> t Deferred.Or_error.t
 

--- a/async/tls_async.ml
+++ b/async/tls_async.ml
@@ -59,9 +59,9 @@ let upgrade_server_reader_writer_to_tls config rw =
   upgrade_connection tls_session rw |> Deferred.ok
 ;;
 
-let upgrade_client_reader_writer_to_tls ?host config rw =
+let upgrade_client_reader_writer_to_tls ?host ?ip config rw =
   let open Deferred.Or_error.Let_syntax in
-  let%bind tls_session = Session.client_of_fd ?host config rw in
+  let%bind tls_session = Session.client_of_fd ?host ?ip config rw in
   upgrade_connection tls_session rw |> Deferred.ok
 ;;
 
@@ -107,14 +107,14 @@ let listen
       upgrade_server_handler ~config (handle_client sock))
 ;;
 
-let upgrade_client_to_tls config ~host outer_reader outer_writer =
+let upgrade_client_to_tls config ~host ?ip outer_reader outer_writer =
   let open Deferred.Or_error.Let_syntax in
   let%bind ( tls_session
            , inner_reader
            , inner_writer
            , `Tls_closed_and_flushed_downstream inner_cafd )
     =
-    upgrade_client_reader_writer_to_tls ?host config (outer_reader, outer_writer)
+    upgrade_client_reader_writer_to_tls ?host ?ip config (outer_reader, outer_writer)
   in
   don't_wait_for
     (let%bind.Deferred () = inner_cafd in
@@ -131,8 +131,9 @@ let connect
       ?timeout
       ?time_source
       config
-      where_to_connect
+      ?ip
       ~host
+      where_to_connect
   =
   let open Deferred.Or_error.Let_syntax in
   let%bind (_ : ([ `Active ], 'a) Socket.t), outer_reader, outer_writer =
@@ -147,7 +148,7 @@ let connect
       where_to_connect
     |> Deferred.ok
   in
-  upgrade_client_to_tls ~host config outer_reader outer_writer
+  upgrade_client_to_tls ~host ?ip config outer_reader outer_writer
 ;;
 
 (* initialized RNG early to maximise available entropy. *)

--- a/async/tls_async.mli
+++ b/async/tls_async.mli
@@ -52,8 +52,9 @@ val upgrade_server_handler
 val connect
   :  ?socket:([ `Unconnected ], 'addr) Socket.t
   -> (Tls.Config.client
-      -> 'addr Tcp.Where_to_connect.t
+      -> ?ip:Ipaddr.t
       -> host:[ `host ] Domain_name.t option
+      -> 'addr Tcp.Where_to_connect.t
       -> (Session.t * Reader.t * Writer.t) Deferred.Or_error.t)
        Tcp.Aliases.with_connect_options
 
@@ -69,6 +70,7 @@ val connect
 val upgrade_client_to_tls
   :  Tls.Config.client
   -> host:[ `host ] Domain_name.t option
+  -> ?ip:Ipaddr.t
   -> Reader.t
   -> Writer.t
   -> (Session.t * Reader.t * Writer.t) Deferred.Or_error.t

--- a/eio/tls_eio.ml
+++ b/eio/tls_eio.ml
@@ -192,10 +192,12 @@ module Raw = struct
       recv_buf = Cstruct.create 4096
     }
 
-  let client_of_flow config ?host flow =
-    let config' = match host with
-      | None -> config
-      | Some host -> Tls.Config.peer config host
+  let client_of_flow config ?host ?ip flow =
+    let config =
+      Option.value ~default:config (Option.map (Tls.Config.peer config) host)
+    in
+    let config' =
+      Option.value ~default:config (Option.map (Tls.Config.ip config) ip)
     in
     let (tls, init) = Tls.Engine.client config' in
     let t = {
@@ -235,8 +237,11 @@ let handler =
 
 let of_t t = Eio.Resource.T (t, handler)
 
-let server_of_flow config       flow = Raw.server_of_flow config       flow |> of_t
-let client_of_flow config ?host flow = Raw.client_of_flow config ?host flow |> of_t
+let server_of_flow config flow =
+  Raw.server_of_flow config flow |> of_t
+
+let client_of_flow config ?host ?ip flow =
+  Raw.client_of_flow config ?host ?ip flow |> of_t
 
 let reneg ?authenticator ?acceptable_cas ?cert ?drop (t:t) = Raw.reneg ?authenticator ?acceptable_cas ?cert ?drop (raw t)
 let key_update ?request (t:t) = Raw.key_update ?request (raw t)

--- a/eio/tls_eio.mli
+++ b/eio/tls_eio.mli
@@ -29,8 +29,8 @@ val server_of_flow :
   Tls.Config.server ->
   [> Eio.Flow.two_way_ty | Eio.Resource.close_ty] r -> t
 
-(** [client_of_flow client ~host fd] is [t], after client-side
-    TLS handshake of [flow] using [client] configuration and [host].
+(** [client_of_flow client ~host ~ip fd] is [t], after client-side
+    TLS handshake of [flow] using [client] configuration and [host] or [ip].
 
     You must ensure a RNG is installed while using TLS, e.g. using [Mirage_crypto_rng_unix.use_default ()].
     Ideally, this would be part of the [client] config so you couldn't forget it,
@@ -40,7 +40,7 @@ val server_of_flow :
 
     @raise End_of_file if the peer closes before the handshake completes. *)
 val client_of_flow :
-  Tls.Config.client -> ?host:[ `host ] Domain_name.t ->
+  Tls.Config.client -> ?host:[ `host ] Domain_name.t -> ?ip:Ipaddr.t ->
   [> Eio.Flow.two_way_ty | Eio.Resource.close_ty] r -> t
 
 (** {2 Control of TLS features} *)

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -581,6 +581,8 @@ and of_client conf = conf
 
 let peer conf name = { conf with peer_name = Some name }
 
+let ip conf ip = { conf with ip = Some ip }
+
 let with_authenticator conf auth = { conf with authenticator = Some auth }
 
 let with_own_certificates conf own_certificates = { conf with own_certificates }

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -94,6 +94,9 @@ val server :
 (** [peer client name] is [client] with [name] as [peer_name] *)
 val peer : client -> [ `host ] Domain_name.t -> client
 
+(** [ip client ip] is [client] with [ip] as [ip] *)
+val ip : client -> Ipaddr.t -> client
+
 (** {1 Note on ALPN protocol selection}
 
     Both {!val:client} and {!val:server} constructors accept an [alpn_protocols] list. The list for server

--- a/lwt/tls_lwt.ml
+++ b/lwt/tls_lwt.ml
@@ -265,10 +265,12 @@ module Unix = struct
   let server_of_fd config fd =
     server_of_fd config (Lwt_fd.of_fd fd)
 
-  let client_of_fd config ?host fd =
-    let config' = match host with
-      | None -> config
-      | Some host -> Tls.Config.peer config host
+  let client_of_fd config ?host ?ip fd =
+    let config =
+      Option.value ~default:config (Option.map (Tls.Config.peer config) host)
+    in
+    let config' =
+      Option.value ~default:config (Option.map (Tls.Config.ip config) ip)
     in
     let (tls, init) = Tls.Engine.client config' in
     let t = {
@@ -281,11 +283,11 @@ module Unix = struct
     write_t t init >>= fun () ->
     drain_handshake t
 
-  let client_of_channels config ?host (ic, oc) =
-    client_of_fd config ?host (Lwt_fd.of_channels ic oc)
+  let client_of_channels config ?host ?ip (ic, oc) =
+    client_of_fd config ?host ?ip (Lwt_fd.of_channels ic oc)
 
-  let client_of_fd config ?host fd =
-    client_of_fd config ?host (Lwt_fd.of_fd fd)
+  let client_of_fd config ?host ?ip fd =
+    client_of_fd config ?host ?ip (Lwt_fd.of_fd fd)
 
   let accept conf fd =
     Lwt_unix.accept fd >>= fun (fd', addr) ->
@@ -298,11 +300,16 @@ module Unix = struct
     resolve host (string_of_int port) >>= fun addr ->
     let fd = Lwt_unix.(socket (Unix.domain_of_sockaddr addr) SOCK_STREAM 0) in
     Lwt.catch (fun () ->
-      let host =
-        Result.to_option
-          (Result.bind (Domain_name.of_string host) Domain_name.host)
-      in
-      Lwt_unix.connect fd addr >>= fun () -> client_of_fd conf ?host fd)
+        let host, ip =
+          match Ipaddr.of_string host with
+          | Error _ ->
+            Result.to_option
+              (Result.bind (Domain_name.of_string host) Domain_name.host),
+            None
+          | Ok ip -> None, Some ip
+        in
+        Lwt_unix.connect fd addr >>= fun () ->
+        client_of_fd conf ?host ?ip fd)
       (function
         | Out_of_memory -> raise Out_of_memory
         | exn -> safely (Lwt_unix.close fd) >>= fun () -> Lwt.reraise exn)

--- a/lwt/tls_lwt.mli
+++ b/lwt/tls_lwt.mli
@@ -42,22 +42,22 @@ module Unix : sig
       @raise End_of_file if the peer closes before the handshake completes. *)
   val server_of_channels : Tls.Config.server -> Lwt_io.input_channel * Lwt_io.output_channel -> t Lwt.t
 
-  (** [client_of_fd client ~host fd] is [t], after client-side
-      TLS handshake of [fd] using [client] configuration and [host].
+  (** [client_of_fd client ~host ~ip fd] is [t], after client-side
+      TLS handshake of [fd] using [client] configuration and [host] or [ip].
 
       Returns a TLS flow which may be fully active or half-closed.
 
       @raise End_of_file if the peer closes before the handshake completes. *)
-  val client_of_fd : Tls.Config.client -> ?host:[ `host ] Domain_name.t -> Lwt_unix.file_descr -> t Lwt.t
+  val client_of_fd : Tls.Config.client -> ?host:[ `host ] Domain_name.t -> ?ip:Ipaddr.t -> Lwt_unix.file_descr -> t Lwt.t
 
-  (** [client_of_channels client ~host (ic, oc)] is [t], after client-side
+  (** [client_of_channels client ~host ~ip (ic, oc)] is [t], after client-side
       TLS handshake over the input/output channels [ic, oc] using [client]
-      configuration and [host].
+      configuration and [host] or [ip].
 
       Returns a TLS flow which may be fully active or half-closed.
 
       @raise End_of_file if the peer closes before the handshake completes. *)
-  val client_of_channels : Tls.Config.client -> ?host:[ `host ] Domain_name.t -> Lwt_io.input_channel * Lwt_io.output_channel -> t Lwt.t
+  val client_of_channels : Tls.Config.client -> ?host:[ `host ] Domain_name.t -> ?ip:Ipaddr.t -> Lwt_io.input_channel * Lwt_io.output_channel -> t Lwt.t
 
   (** [accept server fd] is [t, sockaddr], after accepting a
       client on [fd] and upgrading to a TLS connection. *)

--- a/miou/tls_miou_unix.ml
+++ b/miou/tls_miou_unix.ml
@@ -239,9 +239,12 @@ let shutdown flow mode =
   | `Write_closed _, `write -> ()
   | `Closed, _ -> ()
 
-let client_of_fd conf ?(read_buffer_size = 0x1000) ?host fd =
+let client_of_fd conf ?(read_buffer_size = 0x1000) ?host ?ip fd =
+  let conf =
+    Option.value ~default:conf (Option.map (Tls.Config.peer conf) host)
+  in
   let conf' =
-    match host with None -> conf | Some host -> Tls.Config.peer conf host
+    Option.value ~default:conf (Option.map (Tls.Config.ip conf) ip)
   in
   let tls, init = Tls.Engine.client conf' in
   let tls_flow =
@@ -318,9 +321,13 @@ let connect authenticator (v, port) =
         if Unix.is_inet6_addr inet_addr then Miou_unix.tcpv6 ()
         else Miou_unix.tcpv4 ()
   in
-  let host = Result.to_option Domain_name.(Result.bind (of_string v) host) in
+  let host, ip =
+    match Ipaddr.of_string v with
+    | Error _ -> Result.to_option Domain_name.(Result.bind (of_string v) host), None
+    | Ok ip -> None, Some ip
+  in
   match Miou_unix.connect fd addr with
-  | () -> client_of_fd conf ?host fd
+  | () -> client_of_fd conf ?host ?ip fd
   | exception exn ->
       Miou_unix.close fd;
       raise exn

--- a/miou/tls_miou_unix.mli
+++ b/miou/tls_miou_unix.mli
@@ -72,10 +72,11 @@ val client_of_fd :
   Tls.Config.client ->
   ?read_buffer_size:int ->
   ?host:[ `host ] Domain_name.t ->
+  ?ip:Ipaddr.t ->
   Miou_unix.file_descr ->
   t
-(** [client_of_flow client ~host fd] is [t], after client-side TLS handshake of
-    [fd] using [client] configuration and [host].
+(** [client_of_flow client ~host ~ip fd] is [t], after client-side TLS handshake of
+    [fd] using [client] configuration and [host] or [ip].
 
     Returns a TLS flow which may be fully active or half-closed.
 

--- a/mirage/tls_mirage.ml
+++ b/mirage/tls_mirage.ml
@@ -214,10 +214,12 @@ module Make (F : Mirage_flow.S) = struct
     | `Error _ | `Closed ->
       F.close flow.flow
 
-  let client_of_flow conf ?host flow =
-    let conf' = match host with
-      | None      -> conf
-      | Some host -> Tls.Config.peer conf host
+  let client_of_flow conf ?host ?ip flow =
+    let conf =
+      Option.value ~default:conf (Option.map (Tls.Config.peer conf) host)
+    in
+    let conf' =
+      Option.value ~default:conf (Option.map (Tls.Config.ip conf) ip)
     in
     let (tls, init) = Tls.Engine.client conf' in
     let tls_flow = {

--- a/mirage/tls_mirage.mli
+++ b/mirage/tls_mirage.mli
@@ -36,14 +36,15 @@ module Make (F : Mirage_flow.S) : sig
       This is only supported in TLS 1.3. *)
   val key_update : ?request:bool -> flow -> (unit, [ write_error | `Msg of string ]) result Lwt.t
 
-  (** [client_of_flow client ~host flow] upgrades the existing connection
-      to TLS using the [client] configuration, using [host] as peer name.
+  (** [client_of_flow client ~host ~ip flow] upgrades the existing connection
+      to TLS using the [client] configuration, using [host] as peer name or [ip]
+      as IP address for validation.
 
       Returns a TLS flow which may be fully active or half-closed.
       Returns [Error `Closed] if the peer closes before the handshake
       completes. *)
   val client_of_flow : Tls.Config.client -> ?host:[ `host ] Domain_name.t ->
-     F.flow -> (flow, write_error) result Lwt.t
+    ?ip:Ipaddr.t -> F.flow -> (flow, write_error) result Lwt.t
 
   (** [server_of_flow server flow] upgrades the flow to a TLS
       connection using the [server] configuration.

--- a/unix/tls_unix.ml
+++ b/unix/tls_unix.ml
@@ -244,9 +244,12 @@ let shutdown flow mode =
   | `Write_closed _, `write -> ()
   | `Closed, _ -> ()
 
-let client_of_fd conf ?(read_buffer_size = 0x1000) ?host fd =
+let client_of_fd conf ?(read_buffer_size = 0x1000) ?host ?ip fd =
+  let conf =
+    Option.value ~default:conf (Option.map (Tls.Config.peer conf) host)
+  in
   let conf' =
-    match host with None -> conf | Some host -> Tls.Config.peer conf host
+    Option.value ~default:conf (Option.map (Tls.Config.ip conf) ip)
   in
   let tls, init = Tls.Engine.client conf' in
   let tls_flow =
@@ -325,9 +328,13 @@ let connect authenticator (v, port) =
         else
           Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0
   in
-  let host = Result.to_option Domain_name.(Result.bind (of_string v) host) in
+  let host, ip =
+    match Ipaddr.of_string v with
+    | Error _ -> Result.to_option (Domain_name.(Result.bind (of_string v) host)), None
+    | Ok ip -> None, Some ip
+  in
   match Unix.connect fd addr with
-  | () -> client_of_fd conf ?host fd
+  | () -> client_of_fd conf ?host ?ip fd
   | exception exn ->
       Unix.close fd;
       raise exn

--- a/unix/tls_unix.mli
+++ b/unix/tls_unix.mli
@@ -72,9 +72,10 @@ val client_of_fd :
   Tls.Config.client ->
   ?read_buffer_size:int ->
   ?host:[ `host ] Domain_name.t ->
+  ?ip:Ipaddr.t ->
   Unix.file_descr ->
   t
-(** [client_of_flow client ~host fd] is [t], after client-side TLS handshake of
+(** [client_of_flow client ~host ~ip fd] is [t], after client-side TLS handshake of
     [fd] using [client] configuration and [host].
 
     Succeeds even if the peer has already closed one half of the connection.


### PR DESCRIPTION
Also provide Config.ip with that behaviour. Also, in backends where we resolve, if an IP address is provided, use that directly for validating the certificate to contain the IP address.