### PR TITLE
tls: keep the client role in the TLS 1.3 client KeyUpdate handler

### DIFF
--- a/lib/handshake_client13.ml
+++ b/lib/handshake_client13.ml
@@ -260,7 +260,7 @@ let handle_key_update state req =
         [ `Record (Packet.HANDSHAKE, ku_raw); `Change_enc client_ctx ]
     in
     let session = `TLS13 session' :: state.session in
-    let state' = { state with machina = Server13 Established13 ; session } in
+    let state' = { state with machina = Client13 Established13 ; session } in
     Ok (state', `Change_dec server_ctx :: out)
   | _ -> Error (`Fatal (`Handshake (`Message "couldn't find an earlier session")))
 


### PR DESCRIPTION
Fix a typo (Server13 -> Client13) in the client KeyUpdate handler. The impact is limited: the client is left in the server role, so a following NewSessionTicket is rejected and the connection gets stuck.