### PR TITLE
Let inject_state follow the engine's half-close

### DIFF
--- a/eio/tls_eio.ml
+++ b/eio/tls_eio.ml
@@ -40,7 +40,10 @@ module Raw = struct
     | `Write_closed _, (`read | `read_write) -> `Closed
     | (`Closed | `Error _) as e, (`read | `write | `read_write) -> e
 
-  let inject_state tls = function
+  let inject_state tls state =
+    let state = if Tls.Engine.read_closed tls then half_close state `read else state in
+    let state = if Tls.Engine.write_closed tls then half_close state `write else state in
+    match state with
     | `Active _ -> `Active tls
     | `Read_closed _ -> `Read_closed tls
     | `Write_closed _ -> `Write_closed tls
@@ -62,10 +65,8 @@ module Raw = struct
 
     let handle tls buf =
       match Tls.Engine.handle_tls tls buf with
-      | Ok (state', eof, `Response resp, `Data data) ->
-          let state' = inject_state state' t.state in
-          let state' = Option.(value ~default:state' (map (fun `Eof -> half_close state' `read) eof)) in
-          t.state <- state' ;
+      | Ok (state', _eof, `Response resp, `Data data) ->
+          t.state <- inject_state state' t.state ;
           Option.iter (try_write_t t) resp;
           Option.map Cstruct.of_string data
 
@@ -180,7 +181,7 @@ module Raw = struct
       match t.state with
       | `Active tls | `Read_closed tls ->
         let tls', buf = Tls.Engine.send_close_notify tls in
-        t.state <- inject_state tls' (half_close t.state `write) ;
+        t.state <- inject_state tls' t.state ;
         write_t t buf
       | _ -> ()
 

--- a/lib/engine.ml
+++ b/lib/engine.ml
@@ -547,6 +547,10 @@ let handshake_in_progress s = match s.handshake.machina with
   | Client13 Established13 | Server13 Established13 -> false
   | _ -> true
 
+let read_closed s = s.read_closed
+
+let write_closed s = s.write_closed
+
 (* entry for user data *)
 let send_application_data st css =
   if st.write_closed || not (hs_can_handle_appdata st.handshake) then

--- a/lib/engine.mli
+++ b/lib/engine.mli
@@ -128,6 +128,16 @@ val handle_tls           : state -> string -> ret
     is a handshake in progress or scheduled. *)
 val handshake_in_progress : state -> bool
 
+(** [read_closed state] is [true] if a "close_notify" alert has been received:
+    the peer will send no more messages on this connection. *)
+val read_closed           : state -> bool
+
+(** [write_closed state] is [true] if {!send_close_notify} has sent this side's
+    "close_notify" alert. As RFC 8446, Section 6.1 (Closure Alerts) puts it,
+    that closes the write side of the connection and "does not have any effect
+    on its read side". *)
+val write_closed          : state -> bool
+
 (** [send_application_data tls outs] is [Some (tls', out)] where
     [tls'] is the new tls state, and [out] the cstruct to send over the
     wire (encrypted [outs]) when the TLS session is ready. When the TLS

--- a/lwt/tls_lwt.ml
+++ b/lwt/tls_lwt.ml
@@ -91,7 +91,10 @@ module Unix = struct
     | `Write_closed _, (`read | `read_write) -> `Closed
     | (`Closed | `Error _) as e, (`read | `write | `read_write) -> e
 
-  let inject_state tls = function
+  let inject_state tls state =
+    let state = if Tls.Engine.read_closed tls then half_close state `read else state in
+    let state = if Tls.Engine.write_closed tls then half_close state `write else state in
+    match state with
     | `Active _ -> `Active tls
     | `Read_closed _ -> `Read_closed tls
     | `Write_closed _ -> `Write_closed tls
@@ -123,10 +126,8 @@ module Unix = struct
 
     let handle tls buf =
       match Tls.Engine.handle_tls tls buf with
-      | Ok (state', eof, `Response resp, `Data data) ->
-          let state' = inject_state state' t.state in
-          let state' = Option.(value ~default:state' (map (fun `Eof -> half_close state' `read) eof)) in
-          t.state <- state' ;
+      | Ok (state', _eof, `Response resp, `Data data) ->
+          t.state <- inject_state state' t.state ;
           safely (resp |> when_some (write_t t)) >|= fun () ->
           `Ok data
 
@@ -241,7 +242,7 @@ module Unix = struct
        match t.state with
        | `Active tls | `Read_closed tls ->
          let tls', buf = Tls.Engine.send_close_notify tls in
-         t.state <- inject_state tls' (half_close t.state `write) ;
+         t.state <- inject_state tls' t.state ;
          write_t t buf
        | _ -> Lwt.return_unit) >>= fun () ->
     t.state <- half_close t.state mode;

--- a/miou/tls_miou_unix.ml
+++ b/miou/tls_miou_unix.ml
@@ -49,7 +49,10 @@ let half_close state mode =
   | `Write_closed _, (`read | `read_write) -> `Closed
   | ((`Closed | `Error _) as e), (`read | `write | `read_write) -> e
 
-let inject_state tls = function
+let inject_state tls state =
+  let state = if Tls.Engine.read_closed tls then half_close state `read else state in
+  let state = if Tls.Engine.write_closed tls then half_close state `write else state in
+  match state with
   | `Active _ -> `Active tls
   | `Read_closed _ -> `Read_closed tls
   | `Write_closed _ -> `Write_closed tls
@@ -71,11 +74,9 @@ let write flow str =
 
 let handle flow tls str =
   match Tls.Engine.handle_tls tls str with
-  | Ok (state, eof, `Response resp, `Data data) ->
+  | Ok (state, _eof, `Response resp, `Data data) ->
       Log.debug (fun m -> m "We handled %d byte(s)" (String.length str));
-      let state = inject_state state flow.state in
-      let state = Option.(value ~default:state (map (fun `Eof -> half_close state `read) eof)) in
-      flow.state <- state;
+      flow.state <- inject_state state flow.state;
       let to_close = flow.state = `Closed in
       Option.iter (inhibit $ write flow) resp;
       (* NOTE(dinosaure): [write flow] can set [flow.state]. So we must

--- a/mirage/tls_mirage.ml
+++ b/mirage/tls_mirage.ml
@@ -41,7 +41,10 @@ module Make (F : Mirage_flow.S) = struct
     | `Write_closed _, (`read | `read_write) -> `Closed
     | (`Closed | `Error _) as e, (`read | `write | `read_write) -> e
 
-  let inject_state tls = function
+  let inject_state tls state =
+    let state = if Tls.Engine.read_closed tls then half_close state `read else state in
+    let state = if Tls.Engine.write_closed tls then half_close state `write else state in
+    match state with
     | `Active _ -> `Active tls
     | `Read_closed _ -> `Read_closed tls
     | `Write_closed _ -> `Write_closed tls
@@ -63,10 +66,8 @@ module Make (F : Mirage_flow.S) = struct
   let read_react flow =
     let handle tls buf =
       match Tls.Engine.handle_tls tls buf with
-      | Ok (state, eof, `Response resp, `Data data) ->
-        let state = inject_state state flow.state in
-        let state = Option.(value ~default:state (map (fun `Eof -> half_close state `read) eof)) in
-        flow.state <- state;
+      | Ok (state, _eof, `Response resp, `Data data) ->
+        flow.state <- inject_state state flow.state;
         ( match resp with
           | None     -> Lwt.return @@ Ok ()
           | Some buf -> write_flow flow buf) >>= fun _ ->

--- a/unix/tls_unix.ml
+++ b/unix/tls_unix.ml
@@ -49,7 +49,10 @@ let half_close state mode =
   | `Write_closed _, (`read | `read_write) -> `Closed
   | ((`Closed | `Error _) as e), (`read | `write | `read_write) -> e
 
-let inject_state tls = function
+let inject_state tls state =
+  let state = if Tls.Engine.read_closed tls then half_close state `read else state in
+  let state = if Tls.Engine.write_closed tls then half_close state `write else state in
+  match state with
   | `Active _ -> `Active tls
   | `Read_closed _ -> `Read_closed tls
   | `Write_closed _ -> `Write_closed tls
@@ -76,11 +79,9 @@ let write flow str =
 
 let handle flow tls str =
   match Tls.Engine.handle_tls tls str with
-  | Ok (state, eof, `Response resp, `Data data) ->
+  | Ok (state, _eof, `Response resp, `Data data) ->
       Log.debug (fun m -> m "We handled %d byte(s)" (String.length str));
-      let state = inject_state state flow.state in
-      let state = Option.(value ~default:state (map (fun `Eof -> half_close state `read) eof)) in
-      flow.state <- state;
+      flow.state <- inject_state state flow.state;
       let to_close = flow.state = `Closed in
       Option.iter (inhibit $ write flow) resp;
       (* NOTE(dinosaure): [write flow] can set [flow.state]. So we must


### PR DESCRIPTION
The engine already knows whether a "close_notify" has been received or sent, in `State.t`'s `read_closed` and `write_closed`, but nothing exposes them. So each adapter derives the same two facts a second time: it turns `handle_tls`'s `` `Eof `` into a `half_close ... `read`, and follows its own `send_close_notify` with a `half_close ... `write`.

This PR exposes the two predicates and has `inject_state` apply them, so a state that carries an engine follows that engine's half-close instead of the caller having to remember to say so. That is what #521 and #522 were: a call site that put the engine back without carrying the half-close with it.

The adapters keep their own `half_close`, which still records the closes the engine cannot see, such as a transport EOF or a local `` `read `` shutdown. One commit per backend. tls-async has no such wrapper and is untouched.
